### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/ColorCop/ColorCop/security/code-scanning/2](https://github.com/ColorCop/ColorCop/security/code-scanning/2)

To fix this issue, we should restrict the permissions granted to the GITHUB_TOKEN by specifying a `permissions` block with the minimal required access. For a linting workflow that only checks out code and runs a linter, `contents: read` is generally sufficient and aligns with the principle of least privilege. This block should be added under the job definition for `lint` in `.github/workflows/lint.yml` (i.e., between `lint:` and `runs-on:`), ensuring all steps in this job only get read access to contents unless/until broader permissions are needed. No additional imports or new methods are necessary for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
