### PR TITLE
fix: update GitHub Actions workflows to set minimal permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ jobs:
 
     runs-on: windows-2022
 
+    # Grant minimal read-only access to repository contents
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    # Grant minimal read-only access to repository contents
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+
+    # Grant minimal read-only access to repository contents
+    permissions:
+      contents: read
+
     steps:
     - name: Checkout
       uses: actions/checkout@v5


### PR DESCRIPTION
This fixes the permissions allowed when using the Github actions token so that they only have read access to repository contents.