### PR TITLE
refactor: replace rand() with thread-safe random generation

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -8,4 +8,4 @@ filter=-readability/casting,-readability/braces
 filter=-build/include_subdir,-build/include,-build/header_guard
 
 # Disable runtime checks
-filter=-runtime/printf,-runtime/threadsafe_fn,-runtime/int,-runtime/explicit
+filter=-runtime/printf,-runtime/int,-runtime/explicit

--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -20,8 +20,11 @@
 #include <math.h>
 #include <windows.h>
 #include <winuser.h>
+#include <random>
 
 constexpr int WEBSAFE_STEP = 51;
+constexpr int RGB_MIN = 0;
+constexpr int RGB_MAX = 255;
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -2695,23 +2698,22 @@ void CColorCopDlg::OnOptionsAutocopytoclipboard()
     OnCopytoclip();
 }
 
-
-
-
 void CColorCopDlg::OnColorRandom()
 {
     // Generates a random color and updates
     // current decimal value MOD 256 - make a random value from 0 to 255
-    srand((unsigned) time(NULL));    // seed with the to actually make it random
-    m_Reddec   = rand() % 256;
-    m_Greendec = rand() % 256;
-    m_Bluedec  = rand() % 256;
-    SetStatusBarText(IDS_RANDOMCOLOR,0);
+    // Thread-safe random number generation
+    static thread_local std::mt19937 generator(std::random_device{}());
+    std::uniform_int_distribution<int> distribution(RGB_MIN, RGB_MAX);
+
+    m_Reddec   = distribution(generator);
+    m_Greendec = distribution(generator);
+    m_Bluedec  = distribution(generator);
+
+    SetStatusBarText(IDS_RANDOMCOLOR, 0);
     CalcColorPal();
     OnconvertRGB();
     OnCopytoclip();
-
-
 }
 
 void CColorCopDlg::OnColorReverse()

--- a/ColorCopDlg.h
+++ b/ColorCopDlg.h
@@ -20,7 +20,6 @@
 #define BMP_FILE "\\Color_Cop.bmp"
 #define BMP_FILE_DIR "\\ColorCop"
 
-//#include "WavTipCtrl.h"        // used to add tooltips to the dialog :)
 
 
 class CSystemTray;
@@ -30,7 +29,6 @@ class CColorCopDlg : public CDialog
 // Construction
 public:
     CColorCopDlg(CWnd* pParent = NULL);    // standard constructor
-    //CWavTipCtrl m_tooltip;
     COLORREF ColorHistory[7];
     COLORREF CustColorBank[16];
     int m_Appflags;


### PR DESCRIPTION
Replace non-thread-safe rand()/srand() with C++11 std::mt19937 and std::uniform_int_distribution for generating random RGB colors.

Changes:
- Use thread_local std::mt19937 with std::random_device seeding
- Add RGB_MIN and RGB_MAX constants for clarity
- Remove global state dependency from OnColorRandom()
- Enable runtime/threadsafe_fn cpplint check
- Clean up whitespace

This eliminates race conditions in multithreaded scenarios and provides better random number distribution quality.