### PR TITLE
refactor: unsigned short with uint16_t and short

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -8,4 +8,4 @@ filter=-readability/casting,-readability/braces
 filter=-build/include_subdir,-build/include,-build/header_guard
 
 # Disable runtime checks
-filter=-runtime/printf,-runtime/int,-runtime/explicit
+filter=-runtime/printf,-runtime/explicit

--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -21,6 +21,7 @@
 #include <windows.h>
 #include <winuser.h>
 #include <random>
+#include <cstdint>
 
 constexpr int WEBSAFE_STEP = 51;
 constexpr int RGB_MIN = 0;
@@ -2733,12 +2734,12 @@ void CColorCopDlg::OnColorReverse()
 
 void CColorCopDlg::OnPopupColorConverttograyscale()
 {
-    unsigned short L=0,Min=0,Max=0;
+    uint16_t L = 0, Min = 0, Max = 0;
+
     CString strStatus;
 
     // Converts the current color to grayscale
-
-    if ((m_Reddec == m_Greendec)&&(m_Greendec == m_Bluedec)) {
+    if ((m_Reddec == m_Greendec) && (m_Greendec == m_Bluedec)) {
 
         strStatus.LoadString(IDS_COLOR_GRAY);
         SetStatusBarText(strStatus);
@@ -2760,7 +2761,7 @@ void CColorCopDlg::OnPopupColorConverttograyscale()
 
         Min = __min(m_Reddec,m_Greendec);
         Min = __min(Min,m_Bluedec);
-        L = (int) (Min + Max)/2;
+        L = (int) (Min + Max) / 2;
 
         m_Reddec   = L;
         m_Greendec = L;
@@ -3485,7 +3486,7 @@ void CColorCopDlg::SetStatusBarText(UINT strResource, int toggleVal) {
     return;
 }
 
-BOOL CColorCopDlg::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt)
+BOOL CColorCopDlg::OnMouseWheel(UINT nFlags, int16_t zDelta, CPoint pt)
 {
     // first check if we are magnifying...
 

--- a/ColorCopDlg.h
+++ b/ColorCopDlg.h
@@ -34,9 +34,9 @@ public:
     int m_Appflags;
     int m_iSamplingOffset;
 
-    int WinLocX,WinLocY;
-    unsigned short m_MagLevel;
-    unsigned short m_FloatPrecision;
+    int WinLocX, WinLocY;
+    int16_t m_MagLevel;
+    int16_t m_FloatPrecision;
 
 
 
@@ -270,7 +270,7 @@ protected:
     afx_msg void OnPopupRestore();
     afx_msg void OnPopupExit();
     afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
-    afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
+    afx_msg BOOL OnMouseWheel(UINT nFlags, int16_t zDelta, CPoint pt);
     afx_msg void OnTimer(UINT nIDEvent);
     afx_msg void OnPopupApplicationHelp();
     afx_msg void OnPopupApplicationEasymove();


### PR DESCRIPTION
Fixes lint violations:

ColorCopDlg.cpp:2736: Use int16_t/int64_t/etc, rather than the C type short [runtime/int] [4]
ColorCopDlg.cpp:3488: Use int16_t/int64_t/etc, rather than the C type short [runtime/int] [4]