### PR TITLE
chore: bump version to v5.5.1

### DIFF
--- a/ColorCop.rc
+++ b/ColorCop.rc
@@ -84,7 +84,7 @@ CAPTION "About Color Cop"
 FONT 8, "MS Sans Serif"
 BEGIN
     ICON            IDR_MAINFRAME,IDC_STATIC,12,9,20,20
-    LTEXT           "Color Cop version 5.4.6",IDC_STATIC,40,8,100,8,
+    LTEXT           "Color Cop version 5.5.1",IDC_STATIC,40,8,100,8,
                     SS_NOPREFIX
     LTEXT           "Copyright (C) 1999-2012",IDC_STATIC,40,22,98,8
     LTEXT           "This program is freeware and can be used and distributed freely.",
@@ -177,14 +177,14 @@ BEGIN
             VALUE "Comments", "please email your suggestions\0"
             VALUE "CompanyName", "colorcop.net\0"
             VALUE "FileDescription", "multi-purpose color picker\0"
-            VALUE "FileVersion", "v5.4.6\0"
+            VALUE "FileVersion", "v5.5.1\0"
             VALUE "InternalName", "Color Cop\0"
-            VALUE "LegalCopyright", "Copyright © 2012 Jay Prall\0"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2012 Jay Prall\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "\0"
             VALUE "PrivateBuild", "\0"
             VALUE "ProductName", "Color Cop\0"
-            VALUE "ProductVersion", "v5.4.6\0"
+            VALUE "ProductVersion", "v5.5.1\0"
             VALUE "SpecialBuild", "\0"
         END
     END
@@ -448,7 +448,7 @@ BEGIN
     IDS_COLOR_CONVERT_GRAY  " Color Converted to grayscale"
     IDS_MAGNIFYING          " Magnifying: %d, %d at %dx"
     IDS_APPLICATION_NAME    "Color Cop"
-    IDS_RELATIVE_POS        " W: %d, H: %d, L: %.1f, A°: %1.f"
+    IDS_RELATIVE_POS        " W: %d, H: %d, L: %.1f, Aï¿½: %1.f"
     IDS_EYEDROPPING         " Eyedropping: %d, %d"
     IDS_WEBSAFE             " (WebSafe)"
     IDS_NOT_WEBSAFE         " (not WebSafe)"

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -1,4 +1,4 @@
----------------------------[ Color Cop v5.4.5 ]--------------------------
+---------------------------[ Color Cop v5.5.1 ]--------------------------
 
 Color Cop is a multi-purpose color picker for web designers and
 programmers. It features an eyedropper, magnifier, variable magnification
@@ -222,15 +222,20 @@ https://colorcop.net/donate
 
 ** Requirements ***
 - 24 Bit color
-- A PC running Windows 98/2000/XP/Vista
+- A PC running Windows
 
 
 
 *** Color Cop Revision History ***
+
+v5.5.1 - 12/01/25 - Releasing from Github repository
+                  - Switch to HTML-based help system for improved compatibility and accessibility
+                  - Press F1 to open the new HTML help interface
+
 v5.4.5 - 10/24/07 - added Clarion Hex mode
-	              - added arrow key support while eyedropping or magnifying
-	              - added multi-pixel average sampling 3x3 - 31x31
-	              - started CMYK
+	                - added arrow key support while eyedropping or magnifying
+	                - added multi-pixel average sampling 3x3 - 31x31
+	                - started CMYK
 
 v5.4.2 - 09/19/06 - added Put cursor over Eyedropper on startup feature
                   - fixed minimize on startup so that it doesn't flash when starting
@@ -242,9 +247,9 @@ v5.4  - 09/03/06 - new Icon created by Raul Matei.
                  - changed location of .dat file and .bmp file
                  - updated the domain used in the urls
 
-v5.3  - 02/23/03 : Added Use Cross Hair Cursor, Detect WebSafe color,
-                    Relative position measurements, magnify while eyedropping,
-                    Allow multiple instances, RGB int mode, and RGB float mode
+v5.3  - 02/23/03 - Added Use Cross Hair Cursor, Detect WebSafe color,
+                 - Relative position measurements, magnify while eyedropping,
+                 - Allow multiple instances, RGB int mode, and RGB float mode
 
 v5.2   - 11/23/02 : Added Convert to Grayscale and the ability to
                     click on the magnified area and get that color.

--- a/inno/colorcop.iss
+++ b/inno/colorcop.iss
@@ -2,8 +2,9 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 [Setup]
+AppID={{197A931D-2802-405D-B53E-67DF09D5BE2E}
 AppName=Color Cop
-AppVerName=Color Cop 5.4.6
+AppVerName=Color Cop 5.5.1
 AppPublisher=Jay Prall
 AppPublisherURL=https://colorcop.net
 AppSupportURL=https://colorcop.net


### PR DESCRIPTION
Updated the version now that releasing from Github and the help file is fixed