### PR TITLE
fix(choco): use correct Inno Setup silent flags for install/uninstall

### DIFF
--- a/choco/tools/chocolateyinstall.ps1
+++ b/choco/tools/chocolateyinstall.ps1
@@ -8,9 +8,8 @@ $packageArgs = @{
     packageName    = $packageName
     fileType       = 'exe'
     file           = $installer
-    silentArgs     = '/S'
+    silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
     validExitCodes = @(0)
 }
 
 Install-ChocolateyInstallPackage @packageArgs
-

--- a/choco/tools/chocolateyuninstall.ps1
+++ b/choco/tools/chocolateyuninstall.ps1
@@ -5,9 +5,8 @@ $packageName = 'colorcop'
 $packageArgs = @{
     packageName    = $packageName
     fileType       = 'exe'
-    silentArgs     = '/S'
+    silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
     validExitCodes = @(0)
 }
 
 Uninstall-ChocolateyPackage @packageArgs
-


### PR DESCRIPTION
Replaced incorrect NSIS-style `/S` switch with proper Inno Setup silent flags (`/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-`) in both chocolateyinstall.ps1 and chocolateyuninstall.ps1 to ensure fully silent operation and prevent verifier hangs.