### PR TITLE
fix(linker): remove forced MSVCRT.LIB to resolve Debug CRT conflict

### DIFF
--- a/ColorCop.vcxproj
+++ b/ColorCop.vcxproj
@@ -81,7 +81,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>MSVCRT.LIB;Htmlhelp.lib;kernel32.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Htmlhelp.lib;kernel32.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\Release/ColorCop.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <ProgramDatabaseFile>.\Release/ColorCop.pdb</ProgramDatabaseFile>
@@ -131,7 +131,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
-      <AdditionalDependencies>MSVCRT.LIB;Htmlhelp.lib;kernel32.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Htmlhelp.lib;kernel32.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Bscmake>
       <SuppressStartupBanner>true</SuppressStartupBanner>


### PR DESCRIPTION
Remove explicit MSVCRT.LIB from AdditionalDependencies in ColorCop.vcxproj Link sections (both configurations). Keeps Htmlhelp.lib, kernel32.lib and user32.lib while relying on default CRT linkage, cleaning up the project linker settings.

Closes #91