### PR TITLE
refactor: modernize precompiled header

### DIFF
--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -1125,7 +1125,6 @@ void CColorCopDlg::RGBtoHSL(double R, double G, double B)
 
 void CColorCopDlg::DisplayColor()
 {
-
     CDC *pDC = GetDC();
 
     int soff = 0;
@@ -1135,37 +1134,8 @@ void CColorCopDlg::DisplayColor()
     CBrush greybrush;    //create a grey brush
     greybrush.CreateSolidBrush(0x00808080);
 
-
     pDC->FillSolidRect(buttonrect, RGB(m_Reddec,m_Greendec,m_Bluedec));
     pDC->DrawEdge(buttonrect, EDGE_SUNKEN, BF_RECT);
-
-
-    //testing
-    //HUE
-
-//hue arrows
-    /*
-
-    soff = int(abs(buttonrect.bottom - buttonrect.top) * Hue);
-    pDC->MoveTo(buttonrect.left-5,buttonrect.top+soff);
-    pDC->LineTo(buttonrect.left,buttonrect.top+soff);
-
-
-    //Sat
-    soff = int(abs(buttonrect.right - buttonrect.left) * Sat);
-    pDC->MoveTo(buttonrect.left+soff,buttonrect.top-5);
-    pDC->LineTo(buttonrect.left+soff,buttonrect.top);
-
-    //Lumin
-    soff = int(abs(buttonrect.bottom - buttonrect.top) * Light);
-    pDC->MoveTo(buttonrect.right+5,buttonrect.top+soff);
-    pDC->LineTo(buttonrect.right-1,buttonrect.top+soff);
-
-
-
-*/
-
-
 
     if (m_Appflags & ExpandedDialog) {
 
@@ -1200,7 +1170,7 @@ void CColorCopDlg::DisplayColor()
         insiderect.right = insiderect.left + m_nwide;
         insiderect.bottom = insiderect.top + m_ntall;
 
-        for    (int col = 0; col < 7; col++) {
+        for (int col = 0; col < 7; col++) {
             if (col) {
                 // not the top row
 
@@ -1265,14 +1235,6 @@ void CColorCopDlg::DisplayColor()
 
             pDC->FrameRect(&insiderect, &blackbrush);
             // show the point that the eyedropper is on
-
-/*
-            if (m_Appflags & ExpandedDialog)
-
-                         magrect.TopLeft().x+2, magrect.TopLeft().y+2 , // upper left dest
-                         magrect.Width()-4, magrect.Height()-4,  // width of dest rect
-        }
-*/
         }
     }
 
@@ -1302,7 +1264,7 @@ void CColorCopDlg::OnChangeGreen()
 void CColorCopDlg::OnChangeBlue()
 {
     UpdateData(TRUE);
-    if (m_Bluedec>255)
+    if (m_Bluedec > 255)
     {
         m_Bluedec = 255;
     }
@@ -1314,7 +1276,7 @@ void CColorCopDlg::OnChangeBlue()
 void CColorCopDlg::OnChangeRed()
 {
     UpdateData(TRUE);
-    if (m_Reddec>255) {
+    if (m_Reddec > 255) {
         m_Reddec = 255;
     }
     CalcColorPal();
@@ -1324,7 +1286,7 @@ void CColorCopDlg::OnChangeRed()
 void CColorCopDlg::OnChangeBlack()
 {
     UpdateData(TRUE);
-    if (m_Black>100) {
+    if (m_Black > 100) {
         m_Black = 100;
     }
     CalcColorPal();
@@ -1335,7 +1297,7 @@ void CColorCopDlg::OnChangeBlack()
 void CColorCopDlg::OnChangeCyan()
 {
     UpdateData(TRUE);
-    if (m_Cyan>100) {
+    if (m_Cyan > 100) {
         m_Cyan = 100;
     }
     CalcColorPal();
@@ -1346,7 +1308,7 @@ void CColorCopDlg::OnChangeCyan()
 void CColorCopDlg::OnChangeMagenta()
 {
     UpdateData(TRUE);
-    if (m_Magenta>100) {
+    if (m_Magenta > 100) {
         m_Magenta = 100;
     }
     CalcColorPal();
@@ -1357,7 +1319,7 @@ void CColorCopDlg::OnChangeMagenta()
 void CColorCopDlg::OnChangeYellow()
 {
     UpdateData(TRUE);
-    if (m_Yellow>100) {
+    if (m_Yellow > 100) {
         m_Yellow = 100;
     }
     CalcColorPal();

--- a/StdAfx.cpp
+++ b/StdAfx.cpp
@@ -1,9 +1,10 @@
 // Copyright (c) 2024 Jay Prall
 // SPDX-License-Identifier: MIT
 
-// stdafx.cpp : source file that includes just the standard includes
-//    ColorCop.pch will be the pre-compiled header
-//    stdafx.obj will contain the pre-compiled type information
+// This source file exists solely to build the project's precompiled header.
+// MSVC requires exactly one .cpp file that includes the PCH header so it can
+// compile and cache the expensive system and MFC headers. By isolating this
+// work here, all other source files can compile faster and avoid repeatedly
+// parsing the same large headers.
 
 #include "stdafx.h"
-

--- a/StdAfx.h
+++ b/StdAfx.h
@@ -1,65 +1,49 @@
 // Copyright (c) 2024 Jay Prall
 // SPDX-License-Identifier: MIT
 
-// stdafx.h : include file for standard system include files,
-//  or project specific include files that are used frequently, but
-//      are changed infrequently
-//
-
-#if !defined(AFX_STDAFX_H__EC2A34E8_4FAA_11D3_81A0_A79013DBA62A__INCLUDED_)
-#define AFX_STDAFX_H__EC2A34E8_4FAA_11D3_81A0_A79013DBA62A__INCLUDED_
-
-#if _MSC_VER >= 1000
 #pragma once
-#endif // _MSC_VER >= 1000
 
-
-#define WINVER          0x0501    // Windows XP
-#define _WIN32_WINNT   0x0501    // Windows XP
-
-#define AlwaysOnTop            4
-#define UpperCaseHex        8
-#define OmitPound            16
-#define SnaptoWebsafe        32
-#define AutoCopytoClip        64
-#define MimimizetoTray        128
-#define EasyMove            256
-#define MinimizeonStart        512
-#define ExpandedDialog        1024
-#define ModeHTML            2048
-#define ModeDelphi            4096
-#define ModePowerBuilder    8192
-#define ModeVisualBasic        16384
-#define ModeVisualC            32768
-#define Sampling1            65536
-#define Sampling3x3            131072
-#define Sampling5x5            262144
-#define MultipleInstances    524288
-#define DetectWebsafeColors    1048576
-#define RGBINT                2097152
-#define RGBFLOAT            4194304
-#define MAGWHILEEYEDROP        8388608
-#define USECROSSHAIR        16777216
-#define SETCURSORONEYEDROP    16777216*2
-#define MULTIPIXELSAMPLE    16777216*2*2
-#define SamplingMULTI         16777216*2*2*2
-#define SpaceRGB             16777216*2*2*2*2
-#define SpaceCMYK             16777216*2*2*2*2*2
-#define ModeClarion             16777216*2*2*2*2*2*2
+// Feature flags (bitmask values)
+#define AlwaysOnTop            (1 << 2)
+#define UpperCaseHex           (1 << 3)
+#define OmitPound              (1 << 4)
+#define SnaptoWebsafe          (1 << 5)
+#define AutoCopytoClip         (1 << 6)
+#define MimimizetoTray         (1 << 7)
+#define EasyMove               (1 << 8)
+#define MinimizeonStart        (1 << 9)
+#define ExpandedDialog         (1 << 10)
+#define ModeHTML               (1 << 11)
+#define ModeDelphi             (1 << 12)
+#define ModePowerBuilder       (1 << 13)
+#define ModeVisualBasic        (1 << 14)
+#define ModeVisualC            (1 << 15)
+#define Sampling1              (1 << 16)
+#define Sampling3x3            (1 << 17)
+#define Sampling5x5            (1 << 18)
+#define MultipleInstances      (1 << 19)
+#define DetectWebsafeColors    (1 << 20)
+#define RGBINT                 (1 << 21)
+#define RGBFLOAT               (1 << 22)
+#define MAGWHILEEYEDROP        (1 << 23)
+#define USECROSSHAIR           (1 << 24)
+#define SETCURSORONEYEDROP     (1 << 25)
+#define MULTIPIXELSAMPLE       (1 << 26)
+#define SamplingMULTI          (1 << 27)
+#define SpaceRGB               (1 << 28)
+#define SpaceCMYK              (1 << 29)
+#define ModeClarion            (1 << 30)
 
 #define MULTIPIX_MIN 1
 #define MULTIPIX_MAX 15
 
-#define     PI   (3.1415926535897932384626433832795)
+#define PI (3.1415926535897932384626433832795)
 
-#include <afxwin.h>         // MFC core and standard components
-#include <afxext.h>         // MFC extensions
+// MFC includes
+#include <afxwin.h>
+#include <afxext.h>
 #ifndef _AFX_NO_AFXCMN_SUPPORT
-#include <afxcmn.h>            // MFC support for Windows Common Controls
-#endif // _AFX_NO_AFXCMN_SUPPORT
-
+#include <afxcmn.h>
+#endif
 
 //{{AFX_INSERT_LOCATION}}
-// Microsoft Developer Studio will insert additional declarations immediately before the previous line.
-
-#endif // !defined(AFX_STDAFX_H__EC2A34E8_4FAA_11D3_81A0_A79013DBA62A__INCLUDED_)


### PR DESCRIPTION
- Replace legacy StdAfx include guards with #pragma once
- Remove hard-coded WINVER/_WIN32_WINNT XP targets to use SDK defaults
- Express feature flag constants as bit shifts for readability
- Add clear explanation of the PCH translation unit in StdAfx.cpp
- Remove dead commented-out drawing code in DisplayColor
- Normalize spacing around operators and in for loops for consistency