### PR TITLE
fix: add app.manifest and DPI/compat settings

### DIFF
--- a/ColorCop.vcxproj
+++ b/ColorCop.vcxproj
@@ -76,6 +76,9 @@
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
+    <Manifest>
+      <AdditionalManifestFiles>app.manifest</AdditionalManifestFiles>
+    </Manifest>
     <Link>
       <AdditionalDependencies>Htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\Release/ColorCop.exe</OutputFile>
@@ -101,6 +104,9 @@
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
+    <Manifest>
+      <AdditionalManifestFiles>app.manifest</AdditionalManifestFiles>
+    </Manifest>
     <Link>
       <OutputFile>.\Debug/ColorCop.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/app.manifest
+++ b/app.manifest
@@ -1,56 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 
-  <!-- Identity -->
-  <assemblyIdentity
-    version="1.0.0.0"
-    processorArchitecture="*"
-    name="ColorCop"
-    type="win32"
+	<!-- Identity -->
+	<assemblyIdentity
+	  version="1.0.0.0"
+	  processorArchitecture="*"
+	  name="ColorCop"
+	  type="win32"
   />
 
-  <!-- UAC -->
-  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-    <security>
-      <requestedPrivileges>
-        <!-- Explicitly run with normal user rights -->
-        <requestedExecutionLevel
-          level="asInvoker"
-          uiAccess="false"
+	<!-- UAC -->
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+		<security>
+			<requestedPrivileges>
+				<requestedExecutionLevel
+				  level="asInvoker"
+				  uiAccess="false"
         />
-      </requestedPrivileges>
-    </security>
-  </trustInfo>
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
 
-  <!-- Windows 10 / 11 compatibility -->
-  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-    <application>
-      <!-- Windows 10 -->
-      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-      <!-- Windows 11 -->
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-    </application>
-  </compatibility>
+	<!-- Windows 10 / 11 compatibility -->
+	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+		<application>
+			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+			<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+		</application>
+	</compatibility>
 
-  <!-- DPI Awareness -->
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings>
-      <dpiAwareness>PerMonitorV2</dpiAwareness>
-    </windowsSettings>
-  </application>
+	<!-- DPI Awareness -->
+	<application xmlns="urn:schemas-microsoft-com:asm.v3">
+		<windowsSettings>
+			<!-- Legacy DPI awareness (Vista → Win8.1) -->
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
 
-  <!-- Common Controls v6 -->
-  <dependency>
-    <dependentAssembly>
-      <assemblyIdentity
-        type="win32"
-        name="Microsoft.Windows.Common-Controls"
-        version="6.0.0.0"
-        processorArchitecture="*"
-        publicKeyToken="6595b64144ccf1df"
-        language="*"
+			<!-- Modern DPI awareness (Win10+) -->
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+				PerMonitorV2
+			</dpiAwareness>
+		</windowsSettings>
+	</application>
+
+	<!-- Common Controls v6 -->
+	<dependency>
+		<dependentAssembly>
+			<assemblyIdentity
+			  type="win32"
+			  name="Microsoft.Windows.Common-Controls"
+			  version="6.0.0.0"
+			  processorArchitecture="*"
+			  publicKeyToken="6595b64144ccf1df"
+			  language="*"
       />
-    </dependentAssembly>
-  </dependency>
+		</dependentAssembly>
+	</dependency>
 
 </assembly>


### PR DESCRIPTION
Include app.manifest in both Release and Debug builds by adding AdditionalManifestFiles to the project file. Update app.manifest to enable UAC asInvoker, declare Windows 10/11 supportedOS entries, add legacy <dpiAware> and modern PerMonitorV2 <dpiAwareness> settings, and reference Common Controls v6. Also reformats/cleans up the manifest XML for consistency. These changes ensure correct DPI scaling and modern visual styles at runtime.