### PR TITLE
feat(manifest): declare explicit Windows 7–11 compatibility and norma…

### DIFF
--- a/app.manifest
+++ b/app.manifest
@@ -1,59 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 
-	<!-- Identity -->
-	<assemblyIdentity
-	  version="1.0.0.0"
-	  processorArchitecture="*"
-	  name="ColorCop"
-	  type="win32"
+  <!-- Identity -->
+  <assemblyIdentity
+    version="1.0.0.0"
+    processorArchitecture="*"
+    name="ColorCop"
+    type="win32"
   />
 
-	<!-- UAC -->
-	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-		<security>
-			<requestedPrivileges>
-				<requestedExecutionLevel
-				  level="asInvoker"
-				  uiAccess="false"
+  <!-- UAC -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel
+          level="asInvoker"
+          uiAccess="false"
         />
-			</requestedPrivileges>
-		</security>
-	</trustInfo>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
 
-	<!-- Windows 10 / 11 compatibility -->
-	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-		<application>
-			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-			<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-		</application>
-	</compatibility>
+  <!-- Declare support for Windows 7 through Windows 11 to prevent legacy shims -->
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 11 -->
+      <supportedOS Id="{d782cc4f-4cf3-45da-a0f3-3e8e3cbbf0d5}"/>
+    </application>
+  </compatibility>
 
-	<!-- DPI Awareness -->
-	<application xmlns="urn:schemas-microsoft-com:asm.v3">
-		<windowsSettings>
-			<!-- Legacy DPI awareness (Vista → Win8.1) -->
-			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+  <!-- DPI Awareness -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Legacy DPI awareness (Vista → Win8.1) -->
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
 
-			<!-- Modern DPI awareness (Win10+) -->
-			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
-				PerMonitorV2
-			</dpiAwareness>
-		</windowsSettings>
-	</application>
+      <!-- Modern DPI awareness (Win10+) -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        PerMonitorV2
+      </dpiAwareness>
+    </windowsSettings>
+  </application>
 
-	<!-- Common Controls v6 -->
-	<dependency>
-		<dependentAssembly>
-			<assemblyIdentity
-			  type="win32"
-			  name="Microsoft.Windows.Common-Controls"
-			  version="6.0.0.0"
-			  processorArchitecture="*"
-			  publicKeyToken="6595b64144ccf1df"
-			  language="*"
+  <!-- Common Controls v6 -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
       />
-		</dependentAssembly>
-	</dependency>
+    </dependentAssembly>
+  </dependency>
 
 </assembly>


### PR DESCRIPTION
…lize formatting

Adds supportedOS GUIDs for Windows 7, 8, 8.1, 10, and 11 to prevent legacy compatibility shims. Also reindents the manifest for consistent spacing and readability without changing behavior.