### PR TITLE
style(mfc): normalize brace/spacing; remove legacy _MSC_VER guards; n…

### DIFF
--- a/ColorCop.cpp
+++ b/ColorCop.cpp
@@ -32,13 +32,11 @@ END_MESSAGE_MAP()
 // CColorCopApp construction
 
 
-CColorCopApp::CColorCopApp()
-{
+CColorCopApp::CColorCopApp() {
     m_hMutex = nullptr;
 }
 
-CColorCopApp::~CColorCopApp()
-{
+CColorCopApp::~CColorCopApp() {
     if (m_hMutex != nullptr)
     {
         CloseHandle(m_hMutex);
@@ -53,8 +51,7 @@ CColorCopApp theApp;
 /////////////////////////////////////////////////////////////////////////////
 // CColorCopApp initialization
 
-BOOL CColorCopApp::InitInstance()
-{
+BOOL CColorCopApp::InitInstance() {
     // multiple instances are not allowed?
     if (!(dlg.m_Appflags & MultipleInstances))
     {
@@ -82,14 +79,11 @@ BOOL CColorCopApp::InitInstance()
 }
 
 // uses a Mutex to figure out if there is an instance of color cop running
-bool CColorCopApp::InstanceRunning()
-{
+bool CColorCopApp::InstanceRunning() {
     m_hMutex = CreateMutex(NULL, true, _T("ColorCop_Mutex"));
 
-    if (m_hMutex)
-    {
-        if (GetLastError() == ERROR_ALREADY_EXISTS)
-        {
+    if (m_hMutex) {
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
             CloseHandle(m_hMutex);  // Close the duplicate handle
             return true;
         }
@@ -99,8 +93,7 @@ bool CColorCopApp::InstanceRunning()
     return false;
 }
 
-BOOL CColorCopApp::GetShellFolderPath(char* pShellFolder, char* pShellPath)
-{
+BOOL CColorCopApp::GetShellFolderPath(char* pShellFolder, char* pShellPath) {
     // pShellFolder can be one of the following
     // AppData, Cache, Cookies, Desktop, Favorites, Fonts, History, NetHood,
     // Personal, Printhood, Programs, Recent, SendTo, Start Menu, Startup,
@@ -127,8 +120,7 @@ BOOL CColorCopApp::GetShellFolderPath(char* pShellFolder, char* pShellPath)
     }
 }
 
-CString CColorCopApp::GetTempFolder()
-{
+CString CColorCopApp::GetTempFolder() {
     CString strTmpPath;
 
     GetShellFolderPath("AppData", strTmpPath.GetBuffer(MAX_PATH));
@@ -137,8 +129,7 @@ CString CColorCopApp::GetTempFolder()
     return strTmpPath;
 }
 
-void CColorCopApp::ClipOrCenterWindowToMonitor(HWND hwnd, UINT flags)
-{
+void CColorCopApp::ClipOrCenterWindowToMonitor(HWND hwnd, UINT flags) {
     RECT rc;
     GetWindowRect(hwnd, &rc);
     SetWindowPos(hwnd, NULL, rc.left, rc.top, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
@@ -146,8 +137,7 @@ void CColorCopApp::ClipOrCenterWindowToMonitor(HWND hwnd, UINT flags)
     dlg.WinLocY = rc.top;
 }
 
-BOOL CColorCopApp::InitApplication()
-{
+BOOL CColorCopApp::InitApplication() {
     CString strInitFile = GetTempFolder();
 
     strInitFile += INI_FILE_DIR;
@@ -233,8 +223,7 @@ void CColorCopApp::CloseApplication() {
     return;
 }
 
-void CColorCopApp::Serialize(CArchive& ar)
-{
+void CColorCopApp::Serialize(CArchive& ar) {
     if (ar.IsStoring())    {
         // storing code
         try {

--- a/ColorCop.h
+++ b/ColorCop.h
@@ -7,9 +7,7 @@
 #if !defined(AFX_HTMLCOP_H__EC2A34E4_4FAA_11D3_81A0_A79013DBA62A__INCLUDED_)
 #define AFX_HTMLCOP_H__EC2A34E4_4FAA_11D3_81A0_A79013DBA62A__INCLUDED_
 
-#if _MSC_VER >= 1000
 #pragma once
-#endif // _MSC_VER >= 1000
 
 #ifndef __AFXWIN_H__
     #error include 'stdafx.h' before including this file for PCH

--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -25,8 +25,7 @@ constexpr int WEBSAFE_STEP = 51;
 constexpr int RGB_MIN = 0;
 constexpr int RGB_MAX = 255;
 
-class CAboutDlg : public CDialog
-{
+class CAboutDlg : public CDialog {
 public:
     CAboutDlg();
 
@@ -52,15 +51,13 @@ protected:
     DECLARE_MESSAGE_MAP()
 };
 
-CAboutDlg::CAboutDlg() : CDialog(CAboutDlg::IDD)
-{
+CAboutDlg::CAboutDlg() : CDialog(CAboutDlg::IDD) {
     //{{AFX_DATA_INIT(CAboutDlg)
     //}}AFX_DATA_INIT
 }
 
 
-void CAboutDlg::DoDataExchange(CDataExchange* pDX)
-{
+void CAboutDlg::DoDataExchange(CDataExchange* pDX) {
     CDialog::DoDataExchange(pDX);
     //{{AFX_DATA_MAP(CAboutDlg)
     DDX_Control(pDX, IDC_MAILLINK, m_maillink);
@@ -81,8 +78,7 @@ const char* kpcTrayNotificationMsg_ = "color cop tray notification";
 // CColorCopDlg dialog
 
 CColorCopDlg::CColorCopDlg(CWnd* pParent /*=NULL*/)
-    : CDialog(CColorCopDlg::IDD, pParent)
-{
+    : CDialog(CColorCopDlg::IDD, pParent) {
     //{{AFX_DATA_INIT(CColorCopDlg)
     m_Greendec = 0;
     m_Bluedec = 0;
@@ -101,8 +97,7 @@ CColorCopDlg::CColorCopDlg(CWnd* pParent /*=NULL*/)
     //m_hIcon = AfxGetApp()->LoadIcon(IDR_MAINFRAME);
 }
 
-void CColorCopDlg::DoDataExchange(CDataExchange* pDX)
-{
+void CColorCopDlg::DoDataExchange(CDataExchange* pDX) {
     CDialog::DoDataExchange(pDX);
     //{{AFX_DATA_MAP(CColorCopDlg)
     DDX_Control(pDX, IDC_ColorPick, m_ColorPick);
@@ -241,8 +236,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CColorCopDlg message handlers
 
-BOOL CColorCopDlg::OnInitDialog()
-{
+BOOL CColorCopDlg::OnInitDialog() {
     CDialog::OnInitDialog();
 
     SetupSystemMenu();            // add about and always on top to the system menu
@@ -360,8 +354,7 @@ BOOL CColorCopDlg::OnInitDialog()
 
 
 
-    } else     if (m_Appflags & SETCURSORONEYEDROP)
-    {
+    } else if (m_Appflags & SETCURSORONEYEDROP) {
         m_bvisible = true;
         // don't move the cursor if the app is minimized
         CRect eyerect;
@@ -371,8 +364,7 @@ BOOL CColorCopDlg::OnInitDialog()
     return FALSE;  // return TRUE  unless you set the focus to a control
 }
 
-void CColorCopDlg::SetupSystemMenu()
-{
+void CColorCopDlg::SetupSystemMenu() {
     // Load accelerator resource..
     m_hAcceleratorTable = ::LoadAccelerators(AfxGetInstanceHandle(), MAKEINTRESOURCE(IDR_COLORCOP_ACCEL));
 
@@ -443,8 +435,7 @@ bool CColorCopDlg::LoadPersistentVariables() {
   return retval;
 }
 
-void CColorCopDlg::SetupWindowRects()
-{
+void CColorCopDlg::SetupWindowRects() {
     // setup color window rect based on the Static box
     HWND temphandle;
     CWnd::GetDlgItem(IDC_CPreview, &temphandle);
@@ -561,8 +552,7 @@ void CColorCopDlg::SetupWindowRects()
     GetDlgItem(IDC_BLACK)->MoveWindow(&recttemp);
 }
 
-void CColorCopDlg::OnSysCommand(UINT nID, LPARAM lParam)
-{
+void CColorCopDlg::OnSysCommand(UINT nID, LPARAM lParam) {
     // this is function is called when the user selects an item
     // from the system menu. (right clicking on the minimized program,
     // or right clicking on the system icon
@@ -590,8 +580,7 @@ void CColorCopDlg::OnSysCommand(UINT nID, LPARAM lParam)
                 // uncheck the item
             }
         }
-    } else
-    {
+    } else {
         BOOL bOldMin = bMinimized;    // remember previous state
 
         if (nID == SC_MINIMIZE) {
@@ -610,8 +599,7 @@ void CColorCopDlg::OnSysCommand(UINT nID, LPARAM lParam)
     }
 }
 
-void CColorCopDlg::SetupTaskBarButton()
-{
+void CColorCopDlg::SetupTaskBarButton() {
     if ((bMinimized) && (m_Appflags & MimimizetoTray ))
     {
         // hide the tray icon if it belongs in the system tray
@@ -624,8 +612,7 @@ void CColorCopDlg::SetupTaskBarButton()
     }
 }
 
-void CColorCopDlg::SetupTrayIcon()
-{
+void CColorCopDlg::SetupTrayIcon() {
     if (bMinimized && (pTrayIcon_ == 0) && (m_Appflags & MimimizetoTray)) {
         CString strAppName;
         strAppName.LoadString(IDS_APPLICATION_NAME);
@@ -639,8 +626,7 @@ void CColorCopDlg::SetupTrayIcon()
     }
 }
 
-void CColorCopDlg::OnPaint()
-{
+void CColorCopDlg::OnPaint() {
     if (IsIconic())
     {
         CPaintDC dc(this);
@@ -690,8 +676,7 @@ void CColorCopDlg::OnPaint()
     }
 }
 
-void CColorCopDlg::RecalcZoom()
-{
+void CColorCopDlg::RecalcZoom() {
     if (m_MagLevel <= 0)
         return;
 
@@ -787,20 +772,17 @@ void CColorCopDlg::OnconvertRGB() {
     // controls.
     UpdateData(FALSE);
 
-
     if ((m_isEyedropping) && (m_bCalcColorPal)) {
         CalcColorPal();        // Re-Calculate color palette
     }
     Invalidate(FALSE);    // Call WM_PAINT, but don't erase background
 }
 
-void CColorCopDlg::OnconvertHEX()
-{
+void CColorCopDlg::OnconvertHEX() {
     TestForWebsafe();    // before
 
     // --- Format hex string ---
-    if (m_Appflags & ModeHTML)
-    {
+    if (m_Appflags & ModeHTML) {
         // Always emit full 6‑digit HTML hex
         m_Hexcolor.Format("#%.2x%.2x%.2x",
                           m_Reddec,
@@ -815,23 +797,21 @@ void CColorCopDlg::OnconvertHEX()
     }
 
     // --- Optional prefix removal ---
-    if (m_Appflags & OmitPound)
-    {
-        if ((m_Appflags & ModeHTML) && m_Hexcolor.Left(1) == "#")
+    if (m_Appflags & OmitPound) {
+        if ((m_Appflags & ModeHTML) && m_Hexcolor.Left(1) == "#") {
             m_Hexcolor.Delete(0);
-
-        if ((m_Appflags & ModeDelphi) && m_Hexcolor.Left(1) == "$")
+        }
+        if ((m_Appflags & ModeDelphi) && m_Hexcolor.Left(1) == "$") {
             m_Hexcolor.Delete(0);
+        }
     }
 
     OnCopytoclip();
     Invalidate(FALSE);    // Call WM_PAINT, but don't erase background
 }
 
-void CColorCopDlg::CalcColorPal()
-{
+void CColorCopDlg::CalcColorPal() {
     // generate a new color palette from the current color
-
     setSeedColor();        // step 1. - set the RGB color
                         //         - calc the Hue, Sat, Light
                         //         - create the swatch
@@ -839,8 +819,7 @@ void CColorCopDlg::CalcColorPal()
     handleShifts();
 }
 
-double CColorCopDlg::plusValue(double num)
-{
+double CColorCopDlg::plusValue(double num) {
     num = num + 0.15;
     if (num > 1.0)
         num = 1.0;
@@ -848,8 +827,7 @@ double CColorCopDlg::plusValue(double num)
     return num;
 }
 
-double CColorCopDlg::minusValue(double num)
-{
+double CColorCopDlg::minusValue(double num) {
     num = num - 0.15;
     if (num < 0.0)
         num = num + 1.0;
@@ -857,8 +835,7 @@ double CColorCopDlg::minusValue(double num)
 }
 
 
-void CColorCopDlg::handleShifts()
-{
+void CColorCopDlg::handleShifts() {
     int i;
     setupSwatches();
     printSwatch();
@@ -900,8 +877,7 @@ void CColorCopDlg::handleShifts()
     printSwatch();
 }
 
-void CColorCopDlg::printSwatch()
-{
+void CColorCopDlg::printSwatch() {
     for (int i = 0; i < 6; i++) {
         HSLtoRGB(Swatch[i].A, Swatch[i].B, Swatch[i].C);
         Swatch[i].A = r;
@@ -913,8 +889,7 @@ void CColorCopDlg::printSwatch()
     palcol++;
 }
 
-void CColorCopDlg::setupSwatches()
-{
+void CColorCopDlg::setupSwatches() {
     Swatch[0].A = OrigSwatch.A;
     Swatch[0].B = OrigSwatch.B;
     Swatch[0].C = OrigSwatch.C;
@@ -1012,8 +987,7 @@ void CColorCopDlg::UpdateCMYKFromRGB(int red, int green, int blue) {
     m_Yellow = m_Yellow - m_Black;
 }
 
-void CColorCopDlg::RGBtoHSL(double R, double G, double B)
-{
+void CColorCopDlg::RGBtoHSL(double R, double G, double B) {
     // the function converts the RGB model to the HSL model.
 
     double MinNum, MaxNum, Diff;
@@ -1032,9 +1006,6 @@ void CColorCopDlg::RGBtoHSL(double R, double G, double B)
     }                    // lets give it something
 
     Light = MaxNum / 255.0;            // find the Light
-
-
-
 
     // find the Saturation
     if ((MaxNum == 255) || (MinNum == 0)) {
@@ -1066,8 +1037,7 @@ void CColorCopDlg::RGBtoHSL(double R, double G, double B)
     }
 }
 
-void CColorCopDlg::DisplayColor()
-{
+void CColorCopDlg::DisplayColor() {
     CDC *pDC = GetDC();
 
     int soff = 0;
@@ -1150,15 +1120,15 @@ void CColorCopDlg::DisplayColor()
         pDC->MoveTo(magminus.left + 2, magminus.top + (magminus.bottom - magminus.top)/2);
         pDC->LineTo(magminus.right - 2, magminus.top +  (magminus.bottom - magminus.top)/2);
 
-        if ((m_Appflags & MAGWHILEEYEDROP)&&(m_isEyedropping)&&(!m_MagDrop)) {
+        if ((m_Appflags & MAGWHILEEYEDROP) && (m_isEyedropping) && (!m_MagDrop)) {
             int pxwid = m_MagLevel;
             insiderect = magrect;
-            insiderect.DeflateRect(magrect.Width()/2, magrect.Height()/2);
+            insiderect.DeflateRect(magrect.Width() / 2, magrect.Height() / 2);
             insiderect.InflateRect(3, 3); // mag 4
-            insiderect.left+=4;
-            insiderect.right+=4;
-            insiderect.bottom+=4;
-            insiderect.top+=4;
+            insiderect.left += 4;
+            insiderect.right += 4;
+            insiderect.bottom += 4;
+            insiderect.top += 4;
 
 
             if ((m_Appflags & Sampling3x3) ||
@@ -1177,17 +1147,14 @@ void CColorCopDlg::DisplayColor()
     return;
 }
 
-void CColorCopDlg::OnAbout()
-{
+void CColorCopDlg::OnAbout() {
     CAboutDlg dlg;
     dlg.DoModal();
 }
 
-void CColorCopDlg::OnChangeGreen()
-{
+void CColorCopDlg::OnChangeGreen() {
     UpdateData(TRUE);
-    if (m_Greendec > 255)
-    {
+    if (m_Greendec > 255) {
         m_Greendec = 255;
     }
     CalcColorPal();
@@ -1195,11 +1162,9 @@ void CColorCopDlg::OnChangeGreen()
     OnCopytoclip();
 }
 
-void CColorCopDlg::OnChangeBlue()
-{
+void CColorCopDlg::OnChangeBlue() {
     UpdateData(TRUE);
-    if (m_Bluedec > 255)
-    {
+    if (m_Bluedec > 255) {
         m_Bluedec = 255;
     }
     CalcColorPal();
@@ -1207,8 +1172,7 @@ void CColorCopDlg::OnChangeBlue()
     OnCopytoclip();
 }
 
-void CColorCopDlg::OnChangeRed()
-{
+void CColorCopDlg::OnChangeRed() {
     UpdateData(TRUE);
     if (m_Reddec > 255) {
         m_Reddec = 255;
@@ -1217,8 +1181,7 @@ void CColorCopDlg::OnChangeRed()
     OnconvertRGB();
     OnCopytoclip();
 }
-void CColorCopDlg::OnChangeBlack()
-{
+void CColorCopDlg::OnChangeBlack() {
     UpdateData(TRUE);
     if (m_Black > 100) {
         m_Black = 100;
@@ -1228,8 +1191,7 @@ void CColorCopDlg::OnChangeBlack()
     OnCopytoclip();
 }
 
-void CColorCopDlg::OnChangeCyan()
-{
+void CColorCopDlg::OnChangeCyan() {
     UpdateData(TRUE);
     if (m_Cyan > 100) {
         m_Cyan = 100;
@@ -1239,8 +1201,7 @@ void CColorCopDlg::OnChangeCyan()
     OnCopytoclip();
 }
 
-void CColorCopDlg::OnChangeMagenta()
-{
+void CColorCopDlg::OnChangeMagenta() {
     UpdateData(TRUE);
     if (m_Magenta > 100) {
         m_Magenta = 100;
@@ -1250,8 +1211,7 @@ void CColorCopDlg::OnChangeMagenta()
     OnCopytoclip();
 }
 
-void CColorCopDlg::OnChangeYellow()
-{
+void CColorCopDlg::OnChangeYellow() {
     UpdateData(TRUE);
     if (m_Yellow > 100) {
         m_Yellow = 100;
@@ -1262,8 +1222,7 @@ void CColorCopDlg::OnChangeYellow()
 }
 
 
-void CColorCopDlg::OnColorPick()
-{
+void CColorCopDlg::OnColorPick() {
     // set up the common windows color dialog
     COLORREF temp;
     CColorDialog dlgcolor;

--- a/Label.cpp
+++ b/Label.cpp
@@ -11,8 +11,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // CLabel
 
-CLabel::CLabel()
-{
+CLabel::CLabel() {
     m_crText = GetSysColor(COLOR_WINDOWTEXT);
     m_hBrush = ::CreateSolidBrush(GetSysColor(COLOR_3DFACE));
 
@@ -29,43 +28,37 @@ CLabel::CLabel()
 }
 
 
-CLabel::~CLabel()
-{
+CLabel::~CLabel() {
     m_font.DeleteObject();
     ::DeleteObject(m_hBrush);
 }
 
-CLabel& CLabel::SetText(const CString& strText)
-{
+CLabel& CLabel::SetText(const CString& strText) {
     SetWindowText(strText);
     return *this;
 }
 
-CLabel& CLabel::SetTextColor(COLORREF crText)
-{
+CLabel& CLabel::SetTextColor(COLORREF crText) {
     m_crText = crText;
     RedrawWindow();
     return *this;
 }
 
-CLabel& CLabel::SetFontBold(BOOL bBold)
-{
+CLabel& CLabel::SetFontBold(BOOL bBold) {
     m_lf.lfWeight = bBold ? FW_BOLD : FW_NORMAL;
     ReconstructFont();
     RedrawWindow();
     return *this;
 }
 
-CLabel& CLabel::SetFontUnderline(BOOL bSet)
-{
+CLabel& CLabel::SetFontUnderline(BOOL bSet) {
     m_lf.lfUnderline = bSet;
     ReconstructFont();
     RedrawWindow();
     return *this;
 }
 
-CLabel& CLabel::SetFontItalic(BOOL bSet)
-{
+CLabel& CLabel::SetFontItalic(BOOL bSet) {
     m_lf.lfItalic = bSet;
     ReconstructFont();
     RedrawWindow();
@@ -73,8 +66,7 @@ CLabel& CLabel::SetFontItalic(BOOL bSet)
 }
 
 
-CLabel& CLabel::SetFontSize(int nSize)
-{
+CLabel& CLabel::SetFontSize(int nSize) {
     nSize*=-1;
     m_lf.lfHeight = nSize;
     ReconstructFont();
@@ -83,8 +75,7 @@ CLabel& CLabel::SetFontSize(int nSize)
 }
 
 
-CLabel& CLabel::SetBkColor(COLORREF crBkgnd)
-{
+CLabel& CLabel::SetBkColor(COLORREF crBkgnd) {
     if (m_hBrush)
         ::DeleteObject(m_hBrush);
 
@@ -92,8 +83,7 @@ CLabel& CLabel::SetBkColor(COLORREF crBkgnd)
     return *this;
 }
 
-CLabel& CLabel::SetFontName(const CString& strFont)
-{
+CLabel& CLabel::SetFontName(const CString& strFont) {
     // Use secure CRT helper to avoid C4996 and buffer overruns.
     // sizeof(m_lf.lfFaceName)/sizeof(TCHAR) yields the element count (LF_FACESIZE).
     _tcscpy_s(m_lf.lfFaceName, sizeof(m_lf.lfFaceName) / sizeof(TCHAR), (LPCTSTR)strFont);
@@ -115,8 +105,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CLabel message handlers
 
-HBRUSH CLabel::CtlColor(CDC* pDC, UINT nCtlColor)
-{
+HBRUSH CLabel::CtlColor(CDC* pDC, UINT nCtlColor) {
     // TODO(j4y): Change any attributes of the DC here
     // TODO(j4y): Return a non-NULL brush if the parent's handler should not be called
 
@@ -137,29 +126,24 @@ HBRUSH CLabel::CtlColor(CDC* pDC, UINT nCtlColor)
     return m_hBrush;
 }
 
-void CLabel::ReconstructFont()
-{
+void CLabel::ReconstructFont() {
     m_font.DeleteObject();
     BOOL bCreated = m_font.CreateFontIndirect(&m_lf);
 
     ASSERT(bCreated);
 }
 
-
-
-void CLabel::OnTimer(UINT nIDEvent)
-{
+void CLabel::OnTimer(UINT nIDEvent) {
     m_bState = !m_bState;
 
-    switch (m_Type)
-    {
+    switch (m_Type) {
         case Text:
-            if (m_bState)
+            if (m_bState) {
                 SetWindowText("");
-            else
+            } else {
                 SetWindowText(m_strText);
+            }
         break;
-
         case Background:
             InvalidateRect(NULL, FALSE);
             UpdateWindow();
@@ -169,8 +153,7 @@ void CLabel::OnTimer(UINT nIDEvent)
     CStatic::OnTimer(nIDEvent);
 }
 
-CLabel& CLabel::SetLink(BOOL bLink)
-{
+CLabel& CLabel::SetLink(BOOL bLink) {
     m_bLink = bLink;
 
     if (bLink)
@@ -181,8 +164,7 @@ CLabel& CLabel::SetLink(BOOL bLink)
     return *this;
 }
 
-void CLabel::OnLButtonDown(UINT nFlags, CPoint point)
-{
+void CLabel::OnLButtonDown(UINT nFlags, CPoint point) {
     CString strLink;
 
     GetWindowText(strLink);
@@ -191,8 +173,7 @@ void CLabel::OnLButtonDown(UINT nFlags, CPoint point)
     CStatic::OnLButtonDown(nFlags, point);
 }
 
-BOOL CLabel::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
-{
+BOOL CLabel::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message) {
     if (m_hCursor)
     {
         ::SetCursor(m_hCursor);
@@ -202,8 +183,7 @@ BOOL CLabel::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
     return CStatic::OnSetCursor(pWnd, nHitTest, message);
 }
 
-CLabel& CLabel::SetLinkCursor(HCURSOR hCursor)
-{
+CLabel& CLabel::SetLinkCursor(HCURSOR hCursor) {
     m_hCursor = hCursor;
     return *this;
 }

--- a/Label.h
+++ b/Label.h
@@ -4,9 +4,8 @@
 #if !defined(AFX_LABEL_H__A4EABEC5_2E8C_11D1_B79F_00805F9ECE10__INCLUDED_)
 #define AFX_LABEL_H__A4EABEC5_2E8C_11D1_B79F_00805F9ECE10__INCLUDED_
 
-#if _MSC_VER >= 1000
 #pragma once
-#endif // _MSC_VER >= 1000
+
 // Label.h : header file
 //
 


### PR DESCRIPTION
…o functional change

- Adopt consistent one-line brace style across dialogs and controls.
- Simplify if/else formatting and whitespace.
- Remove obsolete `#if _MSC_VER >= 1000` guards around `#pragma once`.
- No API or behavioral changes; modern MSVCs fully supported.