### PR TITLE
ci: migrate linting to mise tool

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,26 +4,18 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
 
-    # Grant minimal read-only access to repository contents
-    permissions:
-      contents: read
-
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
+    - uses: actions/checkout@v6
 
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
+    - name: Install mise
+      uses: jdx/mise-action@v3
 
-    - name: Install Dependencies
-      run: pip install cpplint
-
-    - name: Run Linters
-      run: ./lint.sh
+    - name: Run linters
+      run: mise run lint

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pip install cpplint
 **Run linting:**
 
 ```sh
-./lint.sh
+mise lint
 ```
 
 ### Contributing

--- a/lint.sh
+++ b/lint.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-cpplint --recursive .

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,10 @@
+[tools]
+python = "3.12"
+
+[tasks.lint]
+description = "Run linters"
+run = [
+  "python -m pip install --upgrade pip",
+  "pip install cpplint",
+  "cpplint --recursive ."
+]


### PR DESCRIPTION
- Move workflow permissions to top-level for better clarity
- Replace custom lint.sh script with mise lint command