### PR TITLE
Refactor default settings and add logging

### DIFF
--- a/ColorCop.cpp
+++ b/ColorCop.cpp
@@ -163,38 +163,31 @@ BOOL CColorCopApp::InitApplication() {
 }
 
 void CColorCopApp::LoadDefaultSettings() {
-    // This function is called when we can't find a .DAT file
-    // with the persistent variables, or it was an old dat file.
-    // Set the default settings and custom colors.
+  // Called when no valid .DAT file exists. Load all default settings.
 
-    dlg.m_Reddec   = GetRValue(kDefaultSeedColor);
-    dlg.m_Greendec = GetGValue(kDefaultSeedColor);
-    dlg.m_Bluedec  = GetBValue(kDefaultSeedColor);
+  // Seed color
+  const COLORREF seed = kDefaultSeedColor;
+  dlg.m_Reddec = GetRValue(seed);
+  dlg.m_Greendec = GetGValue(seed);
+  dlg.m_Bluedec = GetBValue(seed);
 
-    dlg.m_Appflags = 0;
-    dlg.m_Appflags |= AlwaysOnTop;
-    dlg.m_Appflags |= AutoCopytoClip;
-    dlg.m_Appflags |= ModeHTML;
-    dlg.m_Appflags |= EasyMove;
-    dlg.m_Appflags |= Sampling1;
-    dlg.m_Appflags |= ExpandedDialog;
-    dlg.m_Appflags |= MultipleInstances;
-    dlg.m_Appflags |= MAGWHILEEYEDROP;
-    dlg.m_Appflags |= SpaceRGB;
+  // Default app flags
+  dlg.m_Appflags = AlwaysOnTop | AutoCopytoClip | ModeHTML | EasyMove |
+                   Sampling1 | ExpandedDialog | MultipleInstances |
+                   MAGWHILEEYEDROP | SpaceRGB;
 
-    dlg.WinLocX = kDefaultWinLocX;
-    dlg.WinLocY = kDefaultWinLocY;
+  // Window defaults
+  dlg.WinLocX = kDefaultWinLocX;
+  dlg.WinLocY = kDefaultWinLocY;
+  dlg.m_iSamplingOffset = kDefaultSamplingOffset;
 
-    dlg.m_iSamplingOffset = kDefaultSamplingOffset;
+  // Custom colors
+  for (int i = 0; i < kCustomColorCount; ++i)
+    dlg.CustColorBank[i] = kDefaultCustomColor;
 
-    // Set all custom color blocks to the default custom color
-    for (int i = 0; i < kCustomColorCount; ++i) {
-        dlg.CustColorBank[i] = kDefaultCustomColor;
-    }
-
-    for (int i = 0; i < kHistoryCount; ++i) {
-        dlg.ColorHistory[i] = kDefaultColorHistory[i];
-    }
+  // History colors
+  for (int i = 0; i < kHistoryCount; ++i)
+    dlg.ColorHistory[i] = kDefaultColorHistory[i];
 }
 
 void CColorCopApp::CloseApplication() {
@@ -233,6 +226,8 @@ void CColorCopApp::Serialize(CArchive& ar) {
 
             ar << dlg.m_iSamplingOffset;
         } catch (CArchiveException& e) {
+            TRACE("Archive exception caught. Cause = %d, File = %s\n", e.m_cause,
+                  e.m_strFileName ? e.m_strFileName : "(unknown)");
             AfxMessageBox(IDS_ERROR_SAVING);
         }
     } else {
@@ -254,6 +249,8 @@ void CColorCopApp::Serialize(CArchive& ar) {
             }
             ar >> dlg.m_iSamplingOffset;
         } catch (CArchiveException& e) {
+            TRACE("Archive exception caught. Cause = %d, File = %s\n", e.m_cause,
+                  e.m_strFileName ? e.m_strFileName : "(unknown)");
             AfxMessageBox(IDS_ERROR_LOADING);
         }
     }

--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -253,7 +253,7 @@ BOOL CColorCopDlg::OnInitDialog() {
   TestForExpand();  // do not call this before SetupWindowRects();
 
   if (!m_ToolTip.Create(this)) {
-    TRACE0(_T("Unable to create a tool tip obj"));
+    TRACE(_T("Unable to create a tool tip obj"));
   } else {
     m_ToolTip.AddTool(&m_ExpandDialog, IDS_EXPANDEDDIALOG);
     m_ToolTip.AddTool(&m_ColorPick, IDS_CUSTOM_COLOR);
@@ -1543,7 +1543,6 @@ void CColorCopDlg::OnMouseMove(UINT nFlags, CPoint point) {
                         m_Greendec = GetGValue(crefxy);
                         m_Bluedec  = GetBValue(crefxy);
 
-
                         UpdateCMYKFromRGB(m_Reddec, m_Greendec, m_Bluedec);
                         // Black   = minimum(1-Red, 1-Green, 1-Blue)
                         // Cyan    = (1-Red-Black)/(1-Black)
@@ -1569,7 +1568,6 @@ void CColorCopDlg::OnMouseMove(UINT nFlags, CPoint point) {
             ::ReleaseDC(NULL, hdc);    // free up the memory
 
             CString strStatus = "", strWebSafe = "";
-
 
                 if (bRelativePosition)  {
                     // L (Length line = hypotenuse) = SQRT(W² + H²) (show it to 1 decimal)

--- a/Label.cpp
+++ b/Label.cpp
@@ -23,10 +23,7 @@ CLabel::CLabel() {
     m_bLink = TRUE;
     m_hCursor = NULL;
     m_Type = None;
-
-    m_hwndBrush = ::CreateSolidBrush(GetSysColor(COLOR_3DFACE));
 }
-
 
 CLabel::~CLabel() {
     m_font.DeleteObject();
@@ -113,12 +110,6 @@ HBRUSH CLabel::CtlColor(CDC* pDC, UINT nCtlColor) {
         pDC->SelectObject(&m_font);
         pDC->SetTextColor(m_crText);
         pDC->SetBkMode(TRANSPARENT);
-    }
-
-
-    if (m_Type == Background) {
-        if (!m_bState)
-            return m_hwndBrush;
     }
 
     return m_hBrush;

--- a/Label.h
+++ b/Label.h
@@ -32,7 +32,6 @@ class CLabel : public CStatic {
     void ReconstructFont();
     COLORREF    m_crText;
     HBRUSH        m_hBrush;
-    HBRUSH        m_hwndBrush;
     LOGFONT        m_lf;
     CFont        m_font;
     CString        m_strText;


### PR DESCRIPTION
Restructure LoadDefaultSettings to be more concise and readable: use a seed constant, combine app flags into a single expression, and streamline loops for custom colors and history. Add TRACE logging in Serialize() catch blocks to report archive cause and filename for easier debugging. Minor UI/dialog cleanups: replace TRACE0 with TRACE and remove extra blank lines. Remove unused m_hwndBrush field and its creation/special-case handling from CLabel (updated .cpp and .h), cleaning up label resource usage.