### PR TITLE
chore(choco): switch to licenseUrl and normalize file paths

### DIFF
--- a/choco/colorcop.nuspec
+++ b/choco/colorcop.nuspec
@@ -19,7 +19,7 @@ Color Cop is a multi-purpose color picker for Windows, featuring an eyedropper, 
     <supportUrl>https://github.com/ColorCop/ColorCop/issues</supportUrl>
     <docsUrl>https://github.com/ColorCop/ColorCop#readme</docsUrl>
 
-    <license type="file">tools/LICENSE.txt</license>
+    <licenseUrl>https://github.com/ColorCop/ColorCop/blob/main/LICENSE.txt</licenseUrl>
     <iconUrl>https://colorcop.net/images/ccicon.png</iconUrl>
 
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -29,10 +29,10 @@ Color Cop is a multi-purpose color picker for Windows, featuring an eyedropper, 
   </metadata>
 
   <files>
-    <file src="tools\chocolateyinstall.ps1" target="tools" />
-    <file src="tools\chocolateyuninstall.ps1" target="tools" />
-    <file src="tools\colorcop-setup.exe" target="tools" />
-    <file src="tools\LICENSE.txt" target="tools" />
-    <file src="tools\VERIFICATION.txt" target="tools" />
+    <file src="tools/chocolateyinstall.ps1" target="tools" />
+    <file src="tools/chocolateyuninstall.ps1" target="tools" />
+    <file src="tools/colorcop-setup.exe" target="tools" />
+    <file src="tools/LICENSE.txt" target="tools" />
+    <file src="tools/VERIFICATION.txt" target="tools" />
   </files>
 </package>


### PR DESCRIPTION
Replaced the embedded <license type="file"> element with a direct licenseUrl pointing to the repo’s LICENSE.txt for clearer moderation review. Also updated all <file> entries to use forward slashes for consistent, cross-platform path handling in the Chocolatey package.