### PR TITLE
fix(hsl): correct grayscale conversion when S == 0

### DIFF
--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -892,7 +892,7 @@ void CColorCopDlg::setSeedColor() {
 
 void CColorCopDlg::HSLtoRGB(double H, double S, double L) {
     if (S == 0) {
-        r = g = b = S * 255.0;
+        r = g = b = static_cast<int>(L * 255.0);
     } else {
         double h = (H - static_cast<int>(H)) * 6.0;
         int caseH = static_cast<int>(h);


### PR DESCRIPTION
HSL→RGB incorrectly used S*255 for grayscale output, producing black for all zero-saturation colors. Replace with L*255 to match standard HSL behavior and restore correct grayscale rendering.