### PR TITLE
fix(hue): wrap shifted hue back into [0,1) and normalize loop spacing

### DIFF
--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -870,8 +870,9 @@ void CColorCopDlg::setupSwatches() {
 }
 
 double CColorCopDlg::shiftHue(double hue) {
-    double rethue = (hue + (60.0 / 360.0));
-
+    double rethue = hue + (60.0 / 360.0);
+    if (rethue >= 1.0)
+        rethue -= 1.0;
     return rethue;
 }
 
@@ -1063,7 +1064,7 @@ void CColorCopDlg::DisplayColor() {
                 insiderect.top += m_ntall;
                 insiderect.bottom += m_ntall;
             }
-            for (int row = 0; row< 6; row++) {
+            for (int row = 0; row < 6; row++) {
                 pDC->FillSolidRect(insiderect, ColorPal[row][col]);
 
                 insiderect.right += m_nwide;


### PR DESCRIPTION
The hue‑shift calculation previously added 60° (as 60/360) but failed to wrap values ≥ 1.0 back into the valid [0,1) range. This caused incorrect HSL→RGB results for hues near the upper boundary. The new logic subtracts 1.0 when needed to maintain proper cyclic hue behavior.

Also normalizes spacing in the palette row loop (`row < 6`) for consistency with surrounding code.