### PR TITLE
refactor(rc): replace hard‑coded version fields with version.h macros

### DIFF
--- a/ColorCop.rc
+++ b/ColorCop.rc
@@ -1,6 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
 #include "resource.h"
+#include "version.h"
 
 // Generated Help ID header file
 #define APSTUDIO_HIDDEN_SYMBOLS
@@ -84,7 +85,7 @@ CAPTION "About Color Cop"
 FONT 8, "MS Sans Serif"
 BEGIN
     ICON            IDR_MAINFRAME,IDC_STATIC,12,9,20,20
-    LTEXT           "Color Cop version 5.5.7",IDC_STATIC,40,8,100,8,SS_NOPREFIX
+    LTEXT           VER_FULLNAME_STR, IDC_STATIC,40,8,100,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 1999-2012",IDC_STATIC,40,22,98,8
     LTEXT           "This program is freeware and can be used and distributed freely.",IDC_STATIC,13,66,210,8
     LTEXT           "Color Cop was developed by Jay Prall",IDC_STATIC,13,80,217,9
@@ -137,8 +138,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 5,5,7,0
- PRODUCTVERSION 5,5,7,0
+ FILEVERSION VER_FILEVERSION
+ PRODUCTVERSION VER_PRODUCTVERSION
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -156,11 +157,11 @@ BEGIN
             VALUE "Comments", "please email your suggestions"
             VALUE "CompanyName", "colorcop.net"
             VALUE "FileDescription", "multi-purpose color picker"
-            VALUE "FileVersion", "v5.5.7"
+            VALUE "FileVersion",VER_FILEVERSION_STR
             VALUE "InternalName", "Color Cop"
             VALUE "LegalCopyright", "Copyright � 2012 Jay Prall"
             VALUE "ProductName", "Color Cop"
-            VALUE "ProductVersion", "v5.5.7"
+            VALUE "ProductVersion", VER_PRODUCTVERSION_STR
         END
     END
     BLOCK "VarFileInfo"

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -1,4 +1,4 @@
----------------------------[ Color Cop v5.5.7 ]--------------------------
+---------------------------[ Color Cop ]-------------------------------
 
 Color Cop is a multi-purpose color picker for web designers and
 programmers. It features an eyedropper, magnifier, variable magnification

--- a/build.cmd
+++ b/build.cmd
@@ -40,10 +40,12 @@ REM ================================
 REM  GENERATE version.h
 REM ================================
 echo #pragma once> version.h
-echo #define VER_FILEVERSION     %VERSION_NUMERIC%>> version.h
-echo #define VER_FILEVERSION_STR "%VERSION_RAW%">> version.h
-echo #define VER_PRODUCTVERSION  %VERSION_NUMERIC%>> version.h
-echo #define VER_PRODUCTVERSION_STR "%VERSION_RAW%">> version.h
+echo #define VER_FILEVERSION     %VERSION_NUMERIC% >> version.h
+echo #define VER_FILEVERSION_STR "%VERSION_RAW%" >> version.h
+echo #define VER_PRODUCTVERSION  %VERSION_NUMERIC% >> version.h
+echo #define VER_PRODUCTVERSION_STR "%VERSION_RAW%" >> version.h
+echo #define VER_FULLNAME_STR "Color Cop version %VERSION_RAW%" >> version.h
+echo #define AppVersionStr "%VERSION_RAW%%" > installer\version.iss
 
 echo Generated version.h:
 type version.h

--- a/installer/colorcop.iss
+++ b/installer/colorcop.iss
@@ -1,10 +1,11 @@
 ; Inno Setup script for Color Cop
+#include "version.iss"
 
 [Setup]
 AppID={{197A931D-2802-405D-B53E-67DF09D5BE2E}}
 AppName=Color Cop
-AppVersion=5.5.7
-AppVerName=Color Cop 5.5.7
+AppVersion={#AppVersionStr}
+AppVerName=Color Cop {#AppVersionStr}
 AppPublisher=Jay Prall
 AppPublisherURL=https://colorcop.net
 AppSupportURL=https://colorcop.net
@@ -18,7 +19,7 @@ OutputBaseFilename=colorcop-setup
 SetupIconFile=..\Res\idr_main.ico
 Compression=lzma
 SolidCompression=yes
-VersionInfoVersion=5.5.7
+VersionInfoVersion={#AppVersionStr}
 DisableDirPage=yes
 DisableProgramGroupPage=yes
 DisableReadyPage=yes


### PR DESCRIPTION
Adds `#include "version.h"` and replaces all numeric and string version literals in ColorCop.rc with `VER_FILEVERSION`, `VER_PRODUCTVERSION`, and their corresponding string macros. This centralizes version definition, keeps the About box and VERSIONINFO block in sync with the generated version.h, and removes the last remaining hard‑coded 5.5.7 values.