### PR TITLE
chore: add pip ecosystem to dependabot and migrate lint task to requi…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,10 @@ updates:
     directory: /
     schedule:
       interval: monthly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    allow:
+      - dependency-type: direct

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,6 @@ python = "3.12"
 [tasks.lint]
 description = "Run linters"
 run = [
-  "python -m pip install --upgrade pip",
-  "pip install cpplint",
-  "cpplint --recursive ."
+  "pip install -r requirements.txt",
+  "cpplint --recursive .",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cppcheck==1.5.1
+cpplint==2.0.2


### PR DESCRIPTION
…rements.txt

- enable Dependabot updates for pip dependencies in the repo root
- introduce requirements.txt with pinned versions for cpplint and cppcheck
- update mise lint task to install from requirements.txt instead of ad‑hoc pip installs