### PR TITLE
build(lint): add cppcheck MFC macro library and update lint pipeline

### DIFF
--- a/cppcheck-mfc.cfg
+++ b/cppcheck-mfc.cfg
@@ -1,0 +1,33 @@
+<def format="2">
+    <!-- Core MFC class macros -->
+    <define name="BEGIN_MESSAGE_MAP(a,b)" value=""/>
+    <define name="END_MESSAGE_MAP()" value=""/>
+    <define name="IMPLEMENT_DYNAMIC(a,b)" value=""/>
+    <define name="IMPLEMENT_DYNCREATE(a,b)" value=""/>
+    <define name="DECLARE_DYNAMIC(a)" value=""/>
+    <define name="DECLARE_DYNCREATE(a)" value=""/>
+
+    <!-- Message map routing -->
+    <define name="ON_COMMAND(a,b)" value=""/>
+    <define name="ON_BN_CLICKED(a,b)" value=""/>
+    <define name="ON_EN_CHANGE(a,b)" value=""/>
+    <define name="ON_UPDATE_COMMAND_UI(a,b)" value=""/>
+
+    <!-- Window message handlers used in ColorCop -->
+    <define name="ON_WM_PAINT()" value=""/>
+    <define name="ON_WM_QUERYDRAGICON()" value=""/>
+    <define name="ON_WM_SYSCOMMAND()" value=""/>
+    <define name="ON_WM_DESTROY()" value=""/>
+    <define name="ON_WM_TIMER()" value=""/>
+    <define name="ON_WM_CTLCOLOR_REFLECT()" value=""/>
+    <define name="ON_WM_LBUTTONDOWN()" value=""/>
+    <define name="ON_WM_LBUTTONUP()" value=""/>
+    <define name="ON_WM_LBUTTONDBLCLK()" value=""/>
+    <define name="ON_WM_SETCURSOR()" value=""/>
+    <define name="ON_WM_MOUSEMOVE()" value=""/>
+    <define name="ON_WM_RBUTTONDOWN()" value=""/>
+    <define name="ON_WM_RBUTTONUP()" value=""/>
+    <define name="ON_WM_MOUSEWHEEL()" value=""/>
+    <define name="ON_WM_CAPTURECHANGED()" value=""/>
+    <define name="ON_WM_INITMENUPOPUP()" value=""/>
+</def>

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -1,0 +1,7 @@
+unknownMacro:BEGIN_MESSAGE_MAP
+unknownMacro:END_MESSAGE_MAP
+unknownMacro:IMPLEMENT_DYNAMIC
+unknownMacro:IMPLEMENT_DYNCREATE
+unknownMacro:DECLARE_DYNAMIC
+unknownMacro:DECLARE_DYNCREATE
+

--- a/mise.toml
+++ b/mise.toml
@@ -6,4 +6,5 @@ description = "Run linters"
 run = [
   "pip install -r requirements.txt",
   "cpplint --recursive .",
+  "cppcheck --project=ColorCop.vcxproj --library=cppcheck-mfc.cfg --enable=warning,style,performance,portability --inline-suppr --error-exitcode=0 --suppress=missingIncludeSystem --suppressions-list=cppcheck-suppressions.txt",
 ]


### PR DESCRIPTION
Introduce `cppcheck-mfc.cfg` containing project-specific MFC message-map macro definitions to eliminate unknownMacro errors during static analysis.

Add `cppcheck-suppressions.txt` to suppress legacy MFC class macro warnings that are intentionally handled via the custom library.

Update `mise.toml` lint task to use the new cppcheck library and suppressions list, and change `--error-exitcode` to 0 to allow style and portability warnings without failing CI.