### PR TITLE
feat(vscode): add workspace settings and default lint build task

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "editor.unicodeHighlight.nonBasicASCII": true,
+    "editor.unicodeHighlight.ambiguousCharacters": true,
+    "editor.unicodeHighlight.invisibleCharacters": true,
+    "editor.unicodeHighlight.allowedCharacters": {}
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "lint",
+      "type": "shell",
+      "command": "mise",
+      "args": ["run", "lint"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    }
+  ]
+}
+


### PR DESCRIPTION
Adds `.vscode/settings.json` enabling strict Unicode highlighting:
- nonBasicASCII
- ambiguousCharacters
- invisibleCharacters
- allowedCharacters = {}

Adds `.vscode/tasks.json` defining a default build task that runs:
    mise run lint

This makes VS Code's Build command run the same lint workflow used in CI.