### PR TITLE
refactor(dialog): extract CAboutDlg into standalone AboutDlg.{h,cpp}

### DIFF
--- a/AboutDlg.cpp
+++ b/AboutDlg.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 Jay Prall
+// SPDX-License-Identifier: MIT
+
+// AboutDlg.h : implementation file for the About dialog
+//
+#include "pch.h"
+#include "AboutDlg.h"
+#include "resource.h"
+
+BEGIN_MESSAGE_MAP(CAboutDlg, CDialog)
+    // no message handlers
+END_MESSAGE_MAP()
+
+CAboutDlg::CAboutDlg() : CDialog(CAboutDlg::IDD) {
+}
+
+void CAboutDlg::DoDataExchange(CDataExchange* pDX) {
+    CDialog::DoDataExchange(pDX);
+    DDX_Control(pDX, IDC_MAILLINK, m_maillink);
+    DDX_Control(pDX, IDC_LINK, m_link);
+}
+
+BOOL CAboutDlg::OnInitDialog() {
+    CDialog::OnInitDialog();
+
+    m_link.SetLink(TRUE)
+        .SetTextColor(RGB(0, 0, 255))
+        .SetFontUnderline(TRUE)
+        .SetLinkCursor(AfxGetApp()->LoadCursor(IDC_HANDPOINTER));
+
+    m_maillink.SetLink(TRUE)
+        .SetTextColor(RGB(0, 0, 255))
+        .SetFontUnderline(TRUE)
+        .SetLinkCursor(AfxGetApp()->LoadCursor(IDC_HANDPOINTER));
+
+    return TRUE;
+}

--- a/AboutDlg.h
+++ b/AboutDlg.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 Jay Prall
+// SPDX-License-Identifier: MIT
+
+// AboutDlg.h : header file for the About dialog
+//
+#pragma once
+
+#include "pch.h"
+#include "Label.h"
+#include "resource.h"
+
+class CAboutDlg : public CDialog {
+ public:
+    CAboutDlg();
+
+    // Dialog Data
+    enum { IDD = IDD_ABOUTBOX };
+
+ protected:
+    virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+    virtual BOOL OnInitDialog();
+
+    CLabel m_maillink;
+    CLabel m_link;
+
+    DECLARE_MESSAGE_MAP()
+};

--- a/ColorCop.cpp
+++ b/ColorCop.cpp
@@ -3,7 +3,6 @@
 
 // ColorCop.cpp : Defines the class behaviors for the application.
 //
-
 #include "pch.h"
 #include "ColorCop.h"
 #include "ColorCopDlg.h"

--- a/ColorCop.vcxproj
+++ b/ColorCop.vcxproj
@@ -10,13 +10,10 @@
       <Platform>Win32</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1786EBED-8856-4392-AD04-CFC32D438A4A}</ProjectGuid>
   </PropertyGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
@@ -25,43 +22,30 @@
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
     <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-
   <ImportGroup Label="ExtensionSettings" />
-
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
-            Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
-            Label="LocalAppDataPlatform" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
-            Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
-            Label="LocalAppDataPlatform" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-
   <PropertyGroup Label="UserMacros" />
-
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <EnableUAC>true</EnableUAC>
     <UACExecutionLevel>AsInvoker</UACExecutionLevel>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>.\Release\</OutDir>
     <IntDir>.\Release\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>.\Debug\</OutDir>
     <IntDir>.\Debug\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
@@ -90,7 +74,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -118,8 +101,8 @@
       <AdditionalDependencies>Htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemGroup>
+    <ClCompile Include="AboutDlg.cpp" />
     <ClCompile Include="ColorCop.cpp" />
     <ClCompile Include="ColorCopDlg.cpp" />
     <ClCompile Include="colorspace.cpp" />
@@ -130,12 +113,11 @@
     </ClCompile>
     <ClCompile Include="SystemTray.cpp" />
   </ItemGroup>
-
   <ItemGroup>
     <ResourceCompile Include="ColorCop.rc" />
   </ItemGroup>
-
   <ItemGroup>
+    <ClInclude Include="AboutDlg.h" />
     <ClInclude Include="ColorCop.h" />
     <ClInclude Include="ColorCopDlg.h" />
     <ClInclude Include="colorspace.h" />
@@ -144,7 +126,6 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="SystemTray.h" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="Res\ColorCop.rc2" />
     <None Include="Res\cross.cur" />
@@ -155,10 +136,8 @@
     <None Include="Res\cursor_m.cur" />
     <None Include="Res\hand.cur" />
     <None Include="Res\MOVE4WAY.CUR" />
-
     <None Include="app.manifest" />
   </ItemGroup>
-
   <ItemGroup>
     <Image Include="Res\eyeyedropper.ico" />
     <Image Include="Res\ico00001.ico" />
@@ -167,12 +146,9 @@
     <Image Include="Res\icon1.ico" />
     <Image Include="Res\idr_main.ico" />
   </ItemGroup>
-
   <ItemGroup>
     <Text Include="ReadMe.txt" />
   </ItemGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/ColorCop.vcxproj.filters
+++ b/ColorCop.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="SystemTray.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="AboutDlg.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ColorCop.rc">
@@ -59,6 +62,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="SystemTray.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="AboutDlg.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -90,6 +96,7 @@
     <None Include="Res\MOVE4WAY.CUR">
       <Filter>Resource Files</Filter>
     </None>
+    <None Include="app.manifest" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Res\eyeyedropper.ico">

--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -1,12 +1,7 @@
 // Copyright (c) 2024 Jay Prall
 // SPDX-License-Identifier: MIT
 
-/************************************************************************************
- *                                                                                  *
- * ColorCopDlg.cpp :: Color Cop
- *
- ************************************************************************************/
-
+// ColorCopDlg.cpp — ColorCop dialog implementation
 
 // Precompiled header
 #include "pch.h"
@@ -31,50 +26,7 @@ constexpr int WEBSAFE_STEP = 51;
 constexpr int RGB_MIN = 0;
 constexpr int RGB_MAX = 255;
 
-class CAboutDlg : public CDialog {
- public:
-    CAboutDlg();
-
-// Dialog Data
-    //{{AFX_DATA(CAboutDlg) // NOLINT(whitespace/comments)
-    enum { IDD = IDD_ABOUTBOX };
-    CLabel    m_maillink;
-    CLabel    m_link;
-    //}}AFX_DATA // NOLINT(whitespace/comments)
-
-    // ClassWizard generated virtual function overrides
-    //{{AFX_VIRTUAL(CAboutDlg) // NOLINT(whitespace/comments)
- protected:
-    virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-    //}}AFX_VIRTUAL // NOLINT(whitespace/comments)
-
-// Implementation
-
- protected:
-    //{{AFX_MSG(CAboutDlg) // NOLINT(whitespace/comments)
-    virtual BOOL OnInitDialog();
-    //}}AFX_MSG // NOLINT(whitespace/comments)
-    DECLARE_MESSAGE_MAP()
-};
-
-CAboutDlg::CAboutDlg() : CDialog(CAboutDlg::IDD) {
-    //{{AFX_DATA_INIT(CAboutDlg) // NOLINT(whitespace/comments)
-    //}}AFX_DATA_INIT // NOLINT(whitespace/comments)
-}
-
-
-void CAboutDlg::DoDataExchange(CDataExchange* pDX) {
-    CDialog::DoDataExchange(pDX);
-    //{{AFX_DATA_MAP(CAboutDlg) // NOLINT(whitespace/comments)
-    DDX_Control(pDX, IDC_MAILLINK, m_maillink);
-    DDX_Control(pDX, IDC_LINK, m_link);
-    //}}AFX_DATA_MAP // NOLINT(whitespace/comments)
-}
-
-BEGIN_MESSAGE_MAP(CAboutDlg, CDialog)
-    //{{AFX_MSG_MAP(CAboutDlg) // NOLINT(whitespace/comments)
-    //}}AFX_MSG_MAP // NOLINT(whitespace/comments)
-END_MESSAGE_MAP()
+#include "AboutDlg.h"
 
 // Constants
 
@@ -2377,23 +2329,6 @@ void CColorCopDlg::FigurePound() {
 
 void CColorCopDlg::OnUpdateOptionsOmitsymbol(CCmdUI* pCmdUI) {
     pCmdUI->SetCheck((m_Appflags & OmitPound) ? 1 : 0);
-}
-
-BOOL CAboutDlg::OnInitDialog() {
-    CDialog::OnInitDialog();
-
-    // setup the hyperlinks
-    m_link.SetLink(TRUE)
-        .SetTextColor(RGB(0, 0, 255))
-        .SetFontUnderline(TRUE)
-        .SetLinkCursor(AfxGetApp()->LoadCursor(IDC_HANDPOINTER));
-
-    m_maillink.SetLink(TRUE)
-        .SetTextColor(RGB(0, 0, 255))
-        .SetFontUnderline(TRUE)
-        .SetLinkCursor(AfxGetApp()->LoadCursor(IDC_HANDPOINTER));
-
-    return TRUE;
 }
 
 void CColorCopDlg::OnExpandDialog() {

--- a/ColorCopDlg.h
+++ b/ColorCopDlg.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Jay Prall
 // SPDX-License-Identifier: MIT
 
-// ColorCopDlg.h : header file
+// ColorCopDlg.h : header file for the Color Cop dialog
 //
 
 #pragma once


### PR DESCRIPTION
Moves the embedded About dialog class out of ColorCopDlg.cpp into its own compilation units (AboutDlg.h / AboutDlg.cpp). Removes duplicate class definition and OnInitDialog implementation from ColorCopDlg.cpp. Updates vcxproj and filters to include the new files.

No functional changes; behavior remains identical.