### PR TITLE
fix(build): remove unintended trailing '%' in AppVersionStr emitted b…

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -46,7 +46,7 @@ echo #define VER_FILEVERSION_STR "%VERSION_RAW%" >> version.h
 echo #define VER_PRODUCTVERSION  %VERSION_NUMERIC% >> version.h
 echo #define VER_PRODUCTVERSION_STR "%VERSION_RAW%" >> version.h
 echo #define VER_FULLNAME_STR "Color Cop version %VERSION_RAW%" >> version.h
-echo #define AppVersionStr "%VERSION_RAW%%" > installer\version.iss
+echo #define AppVersionStr "%VERSION_RAW%" > installer\version.iss
 
 echo Generated version.h:
 type version.h


### PR DESCRIPTION
…y batch escaping

Batch `echo` collapses `%%` to `%`, causing `"%VERSION_RAW%%"` to produce a literal trailing '%' in installer/version.iss. Updating the line to `"%VERSION_RAW%"` ensures the generated AppVersionStr matches the expected `#define AppVersionStr "0.0.0"` format.