### PR TITLE
chore(choco): replace releaseNotes URL with version placeholder and u…

### DIFF
--- a/.github/workflows/choco-publish.yml
+++ b/.github/workflows/choco-publish.yml
@@ -66,6 +66,7 @@ jobs:
           $version = "${{ steps.get_version.outputs.version }}"
           (Get-Content choco/colorcop.nuspec) `
             -replace '<version>[^<]+</version>', "<version>$version</version>" `
+            -replace 'releases/tag/v0\.0\.0', "releases/tag/v$version" `
             | Set-Content choco/colorcop.nuspec
 
       - name: Generate VERIFICATION.txt

--- a/choco/colorcop.nuspec
+++ b/choco/colorcop.nuspec
@@ -24,7 +24,7 @@ Color Cop is a multi-purpose color picker for Windows, featuring an eyedropper, 
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>color picker eyedropper design developer utility mfc windows</tags>
 
-    <releaseNotes>https://github.com/ColorCop/ColorCop/releases</releaseNotes>
+    <releaseNotes>https://github.com/ColorCop/ColorCop/releases/tag/v0.0.0</releaseNotes> <!-- Replaced by GitHub Action -->
   </metadata>
 
   <files>


### PR DESCRIPTION
…pdate CI to rewrite it

Updates the nuspec to use a version-specific releaseNotes URL placeholder (`v0.0.0`) and extends the choco-publish workflow to rewrite it during packaging. Ensures Chocolatey receives correct per-release notes and keeps the CI replacement logic deterministic.