### PR TITLE
refactor(gdi): introduce WindowDC RAII wrapper and apply it in OnPaint

### DIFF
--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -11,6 +11,7 @@
 #include "ColorCopDlg.h"
 #include "Label.h"       // used for the links in the AboutDlg
 #include "SystemTray.h"  // used to minimize to the systray
+#include "GdiHelpers.h"  // RAII wrapper for window device contexts
 
 // Windows SDK headers (explicit APIs used in this file)
 #include <commctrl.h>
@@ -621,7 +622,7 @@ void CColorCopDlg::OnPaint() {
 
         HWND CCopHWNDtemp = AfxGetApp()->GetMainWnd()->m_hWnd;
 
-        hdc = ::GetDC(CCopHWNDtemp);
+        WindowDC hdc(CCopHWNDtemp);   // RAII — auto‑releases
         if (hBitmap) {
             hdcMem = ::CreateCompatibleDC(hdc);
 
@@ -643,7 +644,6 @@ void CColorCopDlg::OnPaint() {
         if (m_Appflags & ExpandedDialog) {
             ::DrawEdge(hdc, &magrect, EDGE_SUNKEN, BF_RECT);
         }
-        ::ReleaseDC(CCopHWNDtemp, hdc);  // let go of the memory
 
         DisplayColor();    // keep the color window showing
     }

--- a/GdiHelpers.h
+++ b/GdiHelpers.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 Jay Prall
+// SPDX-License-Identifier: MIT
+
+#pragma once
+//
+// GdiHelpers.h
+#include <windows.h>
+
+class WindowDC {
+ public:
+    explicit WindowDC(HWND hwnd)
+        : m_hwnd(hwnd), m_hdc(::GetDC(hwnd)) {}
+
+    ~WindowDC() {
+        if (m_hdc) {
+            ::ReleaseDC(m_hwnd, m_hdc);
+        }
+    }
+
+    operator HDC() const { return m_hdc; }
+
+ private:
+    HWND m_hwnd;
+    HDC  m_hdc;
+};


### PR DESCRIPTION
Add new GdiHelpers.h containing a WindowDC RAII class to manage GetDC/ReleaseDC lifetime automatically. Replace the manual GetDC/ReleaseDC pair in OnPaint() with the new wrapper to ensure deterministic cleanup and eliminate a potential leak. No behavioral changes.