### PR TITLE
docs(installer): add minimal README explaining admin-mode installer a…

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,26 @@
+# Color Cop Installer
+
+This folder contains the Inno Setup script used to build the Color Cop
+Windows installer.
+
+## How it works
+
+- The installer runs in **admin mode** because Color Cop installs into
+  **Program Files (x86)**.
+- It bundles the **VC++ 2015-2022 runtime** (`vc_redist.x86.exe`).
+- The script checks the official registry key to see if the runtime is
+  already installed.
+- If missing, the runtime is installed silently; otherwise it is skipped.
+
+## Building
+
+1. Install Inno Setup 6.x.
+2. Place `vc_redist.x86.exe` in this directory.
+3. Build `colorcop.iss`.
+4. The output installer is written to `../Output/`.
+
+## Files
+
+- `colorcop.iss` - main installer script
+- `version.iss` - version metadata
+- `vc_redist.x86.exe` - bundled runtime (not committed)

--- a/installer/colorcop.iss
+++ b/installer/colorcop.iss
@@ -46,7 +46,7 @@ Filename: "{app}\ColorCop.url"; Section: "InternetShortcut"; Key: "URL"; String:
 [Icons]
 Name: "{group}\Color Cop"; Filename: "{app}\ColorCop.exe"
 Name: "{group}\Website"; Filename: "{app}\ColorCop.url"
-Name: "{userdesktop}\Color Cop"; Filename: "{app}\ColorCop.exe"; Tasks: desktopicon
+Name: "{commondesktop}\Color Cop"; Filename: "{app}\ColorCop.exe"; Tasks: desktopicon
 
 [Run]
 ; Install VC++ runtime if needed


### PR DESCRIPTION
…nd VC++ runtime detection

- Introduce installer/README.md with a concise overview of how the Inno Setup installer works, including admin-mode behavior and bundled VC++ runtime logic.
- Document build steps and file layout for maintainers.
- Switch desktop shortcut from {userdesktop} to {commondesktop} to align with admin install mode and remove UsedUserAreasWarning.