### PR TITLE
feat(portable-mode): add command-line switch to enable portable setti…

### DIFF
--- a/ColorCop.cpp
+++ b/ColorCop.cpp
@@ -51,6 +51,17 @@ CColorCopApp theApp;
 // CColorCopApp initialization
 
 BOOL CColorCopApp::InitInstance() {
+    // Detect portable‑mode command‑line switches (restores pre‑5.3 behavior)
+    CString cmd = GetCommandLine();
+    cmd.MakeLower();
+
+    if (cmd.Find(_T("-portable")) != -1 ||
+        cmd.Find(_T("--portable")) != -1 ||
+        cmd.Find(_T("/portable")) != -1 ||
+        cmd.Find(_T("/p")) != -1) {
+        m_PortableMode = true;
+    }
+
     // multiple instances are not allowed?
     if (!(dlg.m_Appflags & MultipleInstances)) {
         // multiple instances are not allowed. check if we have one running
@@ -63,6 +74,7 @@ BOOL CColorCopApp::InitInstance() {
             }
     }
         // set the main window
+        dlg.m_PortableMode = m_PortableMode;
         m_pMainWnd = &dlg;
 
         int nResponse = dlg.DoModal();        // Launch the color cop dialog
@@ -135,11 +147,20 @@ void CColorCopApp::ClipOrCenterWindowToMonitor(HWND hwnd, UINT flags) {
 }
 
 BOOL CColorCopApp::InitApplication() {
-    CString strInitFile = GetTempFolder();
+    CString strInitFile;
 
-    strInitFile += INI_FILE_DIR;
+    if (m_PortableMode) {
+        TCHAR exePath[MAX_PATH] = {0};
+        GetModuleFileName(NULL, exePath, MAX_PATH);
+        PathRemoveFileSpec(exePath);
 
-    strInitFile += INI_FILE;
+        strInitFile = exePath;
+        strInitFile += INI_FILE;   // "\Color_Cop.dat"
+    } else {
+        strInitFile = GetTempFolder();
+        strInitFile += INI_FILE_DIR;
+        strInitFile += INI_FILE;
+    }
 
     CFile file;
     if (file.Open(strInitFile, CFile::modeRead)) {
@@ -195,11 +216,21 @@ void CColorCopApp::CloseApplication() {
     // last thing the application will do. It will only write to
     // a file when the dialog has been closed IDOK or IDCANCEL
 
-    CString strInitFile = GetTempFolder();
+    CString strInitFile;
 
-    strInitFile += INI_FILE_DIR;
+    if (m_PortableMode) {
+        TCHAR exePath[MAX_PATH] = {0};
+        GetModuleFileName(NULL, exePath, MAX_PATH);
+        PathRemoveFileSpec(exePath);
 
-    strInitFile += INI_FILE;
+        strInitFile = exePath;
+        strInitFile += INI_FILE;   // "\Color_Cop.dat"
+    } else {
+        strInitFile = GetTempFolder();
+        strInitFile += INI_FILE_DIR;
+        strInitFile += INI_FILE;
+    }
+
 
     CFile file;
     if (file.Open(strInitFile, CFile::modeWrite|CFile::modeCreate)) {

--- a/ColorCop.h
+++ b/ColorCop.h
@@ -20,6 +20,8 @@
 //
 class CColorCopApp : public CWinApp {
  public:
+    bool m_PortableMode = false;  // set via command-line switches
+
     CColorCopDlg dlg;
     CColorCopApp();
     ~CColorCopApp();

--- a/ColorCopDlg.h
+++ b/ColorCopDlg.h
@@ -81,19 +81,23 @@ class CColorCopDlg : public CDialog {
     // ClassWizard generated virtual function overrides
     //{{AFX_VIRTUAL(CColorCopDlg) // NOLINT(whitespace/comments)
  public:
-    virtual BOOL PreTranslateMessage(MSG* pMsg);
+    // Indicates whether ColorCop is running in portable mode. When enabled,
+    // all settings are loaded from and saved to the executable directory
+    // instead of the user's AppData folder. The flag is set by the app
+    // during command‑line parsing and used by the dialog's persistence logic.
+    bool m_PortableMode = false;
+    virtual BOOL PreTranslateMessage(MSG *pMsg);
 
  protected:
     virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
     //}}AFX_VIRTUAL // NOLINT(whitespace/comments)
 
-// Implementation
  protected:
     bool m_bvisible;
 
     HICON m_hIcon, m_hBlank, m_hEye;
 
-    HACCEL m_hAcceleratorTable;            // Accelerator var
+    HACCEL m_hAcceleratorTable;
 
     // Store for snapback from websafe; 1‑byte values (0–255)
     std::uint8_t m_OldRed{};


### PR DESCRIPTION
…ngs storage

Implements support for running ColorCop in "portable mode", restoring the behavior of versions prior to 5.3 where settings were stored next to the executable instead of in the user's AppData directory.

Portable mode is activated via any of the following command-line switches:
  -portable
  --portable
  /portable
  /p

When enabled, ColorCop reads and writes Color_Cop.dat from the executable directory, allowing fully self-contained, USB-friendly operation.

Closes #14.