### PR TITLE
Use GetSettingsFolder; support portable mode

### DIFF
--- a/ColorCop.cpp
+++ b/ColorCop.cpp
@@ -129,13 +129,24 @@ BOOL CColorCopApp::GetShellFolderPath(LPCTSTR pShellFolder, LPTSTR pShellPath) {
     }
 }
 
-CString CColorCopApp::GetTempFolder() {
-    CString strTmpPath;
+CString CColorCopApp::GetSettingsFolder() {
+    CString path;
+    if (m_PortableMode) {
+        // Portable mode: store settings next to the EXE
+        TCHAR exePath[MAX_PATH] = {0};
+        GetModuleFileName(NULL, exePath, MAX_PATH);
+        PathRemoveFileSpec(exePath);
+        path = exePath;
+        return path;  // e.g. C:\Tools\ColorCop
+    }
 
-    GetShellFolderPath(_T("AppData"), strTmpPath.GetBuffer(MAX_PATH));
-    strTmpPath.ReleaseBuffer();
+    // Installed mode: use LocalAppData\ColorCop
+    TCHAR buffer[MAX_PATH] = {0};
+    GetShellFolderPath(_T("Local AppData"), buffer);
+    path = buffer;
 
-    return strTmpPath;
+    path += INI_FILE_DIR;  // "\ColorCop"
+    return path;           // e.g. C:\Users\...\AppData\Local\ColorCop
 }
 
 void CColorCopApp::ClipOrCenterWindowToMonitor(HWND hwnd, UINT flags) {
@@ -147,36 +158,22 @@ void CColorCopApp::ClipOrCenterWindowToMonitor(HWND hwnd, UINT flags) {
 }
 
 BOOL CColorCopApp::InitApplication() {
-    CString strInitFile;
-
-    if (m_PortableMode) {
-        TCHAR exePath[MAX_PATH] = {0};
-        GetModuleFileName(NULL, exePath, MAX_PATH);
-        PathRemoveFileSpec(exePath);
-
-        strInitFile = exePath;
-        strInitFile += INI_FILE;   // "\Color_Cop.dat"
-    } else {
-        strInitFile = GetTempFolder();
-        strInitFile += INI_FILE_DIR;
-        strInitFile += INI_FILE;
-    }
+    CString settingsFolder = GetSettingsFolder();
+    CString strInitFile = settingsFolder + INI_FILE;  // "\Color_Cop.dat"
 
     CFile file;
     if (file.Open(strInitFile, CFile::modeRead)) {
         CArchive ar(&file, CArchive::load);
         Serialize(ar);
     } else {
-        // First time we are running color Cop
-        CString strAppDirectory = GetTempFolder();
-        strAppDirectory += INI_FILE_DIR;
-        CreateDirectory(strAppDirectory.GetBuffer(MAX_PATH), NULL);
-        strAppDirectory.ReleaseBuffer();
-
+        // First time running ColorCop
+        if (!m_PortableMode) {
+            // Ensure the settings folder exists
+            CreateDirectory(settingsFolder, NULL);
+        }
         LoadDefaultSettings();
 
         ClipOrCenterWindowToMonitor(::GetForegroundWindow(), MONITOR_CENTER);
-        // set the window to be in the middle
     }
 
     return CWinApp::InitApplication();
@@ -211,26 +208,13 @@ void CColorCopApp::LoadDefaultSettings() {
 }
 
 void CColorCopApp::CloseApplication() {
-    ////////////////////////////////////////////////////////////
-    // This function writes the settings to a file.  It is the
-    // last thing the application will do. It will only write to
-    // a file when the dialog has been closed IDOK or IDCANCEL
+    CString settingsFolder = GetSettingsFolder();
+    CString strInitFile = settingsFolder + INI_FILE;
 
-    CString strInitFile;
-
-    if (m_PortableMode) {
-        TCHAR exePath[MAX_PATH] = {0};
-        GetModuleFileName(NULL, exePath, MAX_PATH);
-        PathRemoveFileSpec(exePath);
-
-        strInitFile = exePath;
-        strInitFile += INI_FILE;   // "\Color_Cop.dat"
-    } else {
-        strInitFile = GetTempFolder();
-        strInitFile += INI_FILE_DIR;
-        strInitFile += INI_FILE;
+    if (!m_PortableMode) {
+        // Ensure folder exists in installed mode
+        CreateDirectory(settingsFolder, NULL);
     }
-
 
     CFile file;
     if (file.Open(strInitFile, CFile::modeWrite|CFile::modeCreate)) {

--- a/ColorCop.h
+++ b/ColorCop.h
@@ -25,16 +25,21 @@ class CColorCopApp : public CWinApp {
     CColorCopDlg dlg;
     CColorCopApp();
     ~CColorCopApp();
+    /* Returns the folder used to store the application's persistent state,
+     * including ColorCop.ini and other configuration files. This ensures the
+     * user's settings and preferences are preserved across application
+     * launches. If the application is running in portable mode, this will
+     * return the executable directory. Otherwise, it will return a folder in
+     * the user's AppData directory.
+     */
+    CString GetSettingsFolder();
 
  protected:
     void CloseApplication();
     void LoadDefaultSettings();
-    CString GetTempFolder();
     BOOL GetShellFolderPath(LPCTSTR pShellFolder, LPTSTR pShellPath);
     void ClipOrCenterWindowToMonitor(HWND hwnd, UINT flags);
-    // multi mon
     void ClipOrCenterRectToMonitor(LPRECT prc, UINT flags);
-
     bool InstanceRunning();
     HANDLE m_hMutex;
 

--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -384,10 +384,15 @@ void CColorCopDlg::SetupSystemMenu() {
 }
 
 bool CColorCopDlg::LoadPersistentVariables() {
+    TRACE(_T("Portable mode: %d\n"), m_PortableMode);
+
     // Build full bitmap path safely
-    CString strBMPFile = GetTempFolder();
+    auto *pApp = static_cast<CColorCopApp *>(AfxGetApp());
+    CString strBMPFile = pApp->GetSettingsFolder();
     strBMPFile += BMP_FILE_DIR;
     strBMPFile += BMP_FILE;
+
+    TRACE(_T("BMP path: %s\n"), strBMPFile);
 
     // Load bitmap from file
     hBitmap = reinterpret_cast<HBITMAP>(
@@ -2050,13 +2055,6 @@ BOOL CColorCopDlg::GetShellFolderPath(LPCTSTR pShellFolder, LPTSTR pShellPath) {
         return FALSE;
 }
 
-CString CColorCopDlg::GetTempFolder() {
-    CString strTmpPath;
-    GetShellFolderPath(_T("AppData"), strTmpPath.GetBuffer(MAX_PATH));
-    strTmpPath.ReleaseBuffer();
-    return strTmpPath;
-}
-
 void CColorCopDlg::OnDestroy() {
     // Capture and store the dialog’s last on-screen position so it can be
     // restored the next time the application starts.
@@ -2066,10 +2064,13 @@ void CColorCopDlg::OnDestroy() {
     WinLocY = winSize.top;
 
     // save the bitmap
-    CString strBMPFile = GetTempFolder();
-
+    auto *pApp = static_cast<CColorCopApp *>(AfxGetApp());
+    CString strBMPFile = pApp->GetSettingsFolder();
     strBMPFile += BMP_FILE_DIR;
     strBMPFile += BMP_FILE;
+
+    TRACE(_T("Portable mode: %d\n"), m_PortableMode);
+    TRACE(_T("BMP path: %s\n"), strBMPFile);
 
     HWND curwindowhwnd = ::GetForegroundWindow();
 

--- a/ColorCopDlg.h
+++ b/ColorCopDlg.h
@@ -191,11 +191,8 @@ class CColorCopDlg : public CDialog {
     void GetHistoryColor(int Cindex);
     HBITMAP CopyBitmap(HBITMAP hBitmapSrc);
     bool isWebsafeColor(int R, int G, int B);
-    CString GetTempFolder();
     BOOL GetShellFolderPath(LPCTSTR pShellFolder, LPTSTR pShellPath);
-
     void SetStatusBarText(UINT strResource, int toggleVal);
-
     void CalcColorPal();
     double shiftHue(double hue);
     void setSeedColor();


### PR DESCRIPTION
Introduce CColorCopApp::GetSettingsFolder to centralize where settings and assets are stored. In portable mode the folder is the executable directory; otherwise it uses Local AppData\ColorCop. Replace various GetTempFolder usages with GetSettingsFolder in InitApplication, CloseApplication and the dialog to unify path handling and ensure the settings folder is created for installed mode. Remove deprecated GetTempFolder declarations/definitions and add TRACE logging in the dialog when loading/saving bitmaps for easier debugging.