### PR TITLE
fix: portable init logic

### DIFF
--- a/ColorCop.cpp
+++ b/ColorCop.cpp
@@ -51,17 +51,6 @@ CColorCopApp theApp;
 // CColorCopApp initialization
 
 BOOL CColorCopApp::InitInstance() {
-    // Detect portable‑mode command‑line switches (restores pre‑5.3 behavior)
-    CString cmd = GetCommandLine();
-    cmd.MakeLower();
-
-    if (cmd.Find(_T("-portable")) != -1 ||
-        cmd.Find(_T("--portable")) != -1 ||
-        cmd.Find(_T("/portable")) != -1 ||
-        cmd.Find(_T("/p")) != -1) {
-        m_PortableMode = true;
-    }
-
     // multiple instances are not allowed?
     if (!(dlg.m_Appflags & MultipleInstances)) {
         // multiple instances are not allowed. check if we have one running
@@ -158,8 +147,19 @@ void CColorCopApp::ClipOrCenterWindowToMonitor(HWND hwnd, UINT flags) {
 }
 
 BOOL CColorCopApp::InitApplication() {
+    // Detect portable‑mode command‑line switches (restores pre‑5.3 behavior)
+    CString cmd = GetCommandLine();
+    cmd.MakeLower();
+
+    if (cmd.Find(_T("-portable")) != -1 || cmd.Find(_T("--portable")) != -1 ||
+        cmd.Find(_T("/portable")) != -1 || cmd.Find(_T("/p")) != -1) {
+        m_PortableMode = true;
+    }
     CString settingsFolder = GetSettingsFolder();
     CString strInitFile = settingsFolder + INI_FILE;  // "\Color_Cop.dat"
+
+    TRACE(_T("Portable mode: %d\n"), m_PortableMode);
+    TRACE(_T("INI path: %s\n"), strInitFile);
 
     CFile file;
     if (file.Open(strInitFile, CFile::modeRead)) {
@@ -210,6 +210,9 @@ void CColorCopApp::LoadDefaultSettings() {
 void CColorCopApp::CloseApplication() {
     CString settingsFolder = GetSettingsFolder();
     CString strInitFile = settingsFolder + INI_FILE;
+
+    TRACE(_T("Portable mode: %d\n"), m_PortableMode);
+    TRACE(_T("INI path: %s\n"), strInitFile);
 
     if (!m_PortableMode) {
         // Ensure folder exists in installed mode

--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -389,7 +389,6 @@ bool CColorCopDlg::LoadPersistentVariables() {
     // Build full bitmap path safely
     auto *pApp = static_cast<CColorCopApp *>(AfxGetApp());
     CString strBMPFile = pApp->GetSettingsFolder();
-    strBMPFile += BMP_FILE_DIR;
     strBMPFile += BMP_FILE;
 
     TRACE(_T("BMP path: %s\n"), strBMPFile);
@@ -2066,7 +2065,6 @@ void CColorCopDlg::OnDestroy() {
     // save the bitmap
     auto *pApp = static_cast<CColorCopApp *>(AfxGetApp());
     CString strBMPFile = pApp->GetSettingsFolder();
-    strBMPFile += BMP_FILE_DIR;
     strBMPFile += BMP_FILE;
 
     TRACE(_T("Portable mode: %d\n"), m_PortableMode);
@@ -3137,7 +3135,7 @@ void CColorCopDlg::CreateBMPFile(HWND /*hwnd*/, LPTSTR pszFile,
                    FILE_ATTRIBUTE_NORMAL,
                    (HANDLE) NULL);
     if (hf == INVALID_HANDLE_VALUE) {
-        AfxMessageBox(_T("Could not create BMP file"));
+        TRACE(_T("Warning: Could not create BMP file: %s (error=%lu)\n"), pszFile, GetLastError());
         return;
     }
 


### PR DESCRIPTION
Detect portable-mode in InitApplication (restoring pre-5.3 behavior) and add TRACE logging of portable mode and INI path in InitApplication and CloseApplication for easier debugging. Remove BMP_FILE_DIR when building BMP file paths in ColorCopDlg so the settings folder is used directly. Replace AfxMessageBox on BMP creation failure with a TRACE warning that includes the filename and GetLastError(). These changes centralize portable detection, improve diagnostics, and fix BMP path handling.