### PR TITLE
feat(workflow): add draft Microsoft Store publishing workflow

### DIFF
--- a/.github/workflows/microsoft-publish.yml
+++ b/.github/workflows/microsoft-publish.yml
@@ -1,0 +1,93 @@
+name: Publish Microsoft Store Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish to Microsoft Store (e.g., v1.0.0)"
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    # Grant minimal read-only access to repository contents
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Determine version + tag
+        id: get_version
+        run: |
+          tag="${{ github.event.inputs.tag }}"
+          version="${tag#v}"
+
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Download release asset
+        run: |
+          gh release download ${{ steps.get_version.outputs.tag }} \
+            --repo ${{ github.repository }} \
+            --pattern "colorcop-setup.exe"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Acquire Microsoft Store access token
+        id: token
+        run: |
+          token=$(curl -s -X POST \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=${{ secrets.STORE_CLIENT_ID }}" \
+            -d "client_secret=${{ secrets.STORE_CLIENT_SECRET }}" \
+            -d "resource=https://manage.devcenter.microsoft.com" \
+            "https://login.microsoftonline.com/${{ secrets.STORE_TENANT_ID }}/oauth2/token" \
+            | jq -r '.access_token')
+
+          if [ -z "$token" ]; then
+            echo "Failed to acquire access token"
+            exit 1
+          fi
+
+          echo "token=$token" >> $GITHUB_OUTPUT
+
+      - name: Create new submission
+        id: submission
+        run: |
+          response=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ steps.token.outputs.token }}" \
+            -H "Content-Type: application/json" \
+            "https://manage.devcenter.microsoft.com/v1.0/my/applications/${{ secrets.STORE_PRODUCT_ID }}/submissions")
+
+          echo "$response" | jq .
+
+          id=$(echo "$response" | jq -r '.id')
+
+          if [ -z "$id" ] || [ "$id" = "null" ]; then
+            echo "Failed to create submission"
+            exit 1
+          fi
+
+          echo "id=$id" >> $GITHUB_OUTPUT
+
+      - name: Upload installer
+        run: |
+          curl -s -X PUT \
+            -H "Authorization: Bearer ${{ steps.token.outputs.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary @colorcop-setup.exe \
+            "https://manage.devcenter.microsoft.com/v1.0/my/applications/${{ secrets.STORE_PRODUCT_ID }}/submissions/${{ steps.submission.outputs.id }}/files/colorcop-setup.exe"
+
+      - name: Commit submission
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer ${{ steps.token.outputs.token }}" \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "https://manage.devcenter.microsoft.com/v1.0/my/applications/${{ secrets.STORE_PRODUCT_ID }}/submissions/${{ steps.submission.outputs.id }}/commit"
+
+          echo "Submission committed for certification"


### PR DESCRIPTION
This introduces a new GitHub Actions workflow (`microsoft-publish.yml`) that manually publishes ColorCop to the Microsoft Store using the Microsoft Store Submission API.

The workflow mirrors the structure and ergonomics of the existing Chocolatey publishing workflow:

- triggered manually via `workflow_dispatch`
- requires a `tag` input (e.g., v5.5.2)
- downloads the corresponding release asset from GitHub
- acquires a Partner Center access token
- creates a new Store submission
- uploads the EXE installer
- commits the submission for certification

Notes:
- This workflow is a **draft** and has not yet been tested end‑to‑end.
- API behavior, submission schema, and file upload paths may require adjustments after initial validation.
- No changes were made to existing workflows.