### PR TITLE
refactor: modernize file headers and clean up outdated comments

### DIFF
--- a/ColorCop.cpp
+++ b/ColorCop.cpp
@@ -1,8 +1,10 @@
 // Copyright (c) 2024 Jay Prall
 // SPDX-License-Identifier: MIT
 
-// ColorCop.cpp : Defines the class behaviors for the application.
-//
+// ColorCop.cpp : Application entry point and core initialization logic.
+// Handles single‑instance enforcement, portable‑mode detection, settings
+// loading/saving, and creation of the main ColorCop dialog.
+
 #include "pch.h"
 #include "ColorCop.h"
 #include "ColorCopDlg.h"

--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -1,7 +1,9 @@
 // Copyright (c) 2024 Jay Prall
 // SPDX-License-Identifier: MIT
 
-// ColorCopDlg.cpp — ColorCop dialog implementation
+// ColorCopDlg.cpp — Core UI implementation for the ColorCop application.
+// Provides dialog setup, control wiring, color sampling and conversion logic,
+// magnifier rendering, system‑tray behavior, and loading/saving of user settings.
 
 // Precompiled header
 #include "pch.h"
@@ -39,9 +41,6 @@ constexpr int kMagButtonSize = 11;
 // Constants
 
 const TCHAR* kpcTrayNotificationMsg_ = _T("color cop tray notification");
-
-/////////////////////////////////////////////////////////////////////////////
-// CColorCopDlg dialog
 
 CColorCopDlg::CColorCopDlg(CWnd* pParent /*=NULL*/)
     : CDialog(CColorCopDlg::IDD, pParent),
@@ -562,10 +561,7 @@ void CColorCopDlg::SetupWindowRects() {
 }
 
 void CColorCopDlg::OnSysCommand(UINT nID, LPARAM lParam) {
-    // this is function is called when the user selects an item
-    // from the system menu. (right clicking on the minimized program,
-    // or right clicking on the system icon
-
+    // Handle system‑menu commands (About, Options, Always‑on‑Top, minimize/restore)
     if ((nID & 0xFFF0) == IDM_ABOUTBOX) {
         CAboutDlg dlgAbout;
         dlgAbout.DoModal();
@@ -642,7 +638,7 @@ void CColorCopDlg::OnPaint() {
         dc.DrawIcon(x, y, m_hIcon);
     } else {
         CDialog::OnPaint();
-        // only paint here..
+        // Custom magnifier rendering and color preview drawing
         HWND hWndMain = GetSafeHwnd();
 
         WindowDC hdc(hWndMain);   // RAII — auto‑releases

--- a/ColorCopDlg.h
+++ b/ColorCopDlg.h
@@ -10,10 +10,6 @@
 
 #include "Defaults.h"
 
-
-/////////////////////////////////////////////////////////////////////////////
-// CColorCopDlg dialog
-
 constexpr double HUE_ROTATION_STEP = 60.0 / 360.0;   // one-sixth of the color wheel
 constexpr double SAT_LIGHT_SHIFT   = 0.15;           // amount to adjust saturation/lightness
 constexpr int    NUM_SWATCHES      = 6;              // number of hue variants

--- a/Defaults.h
+++ b/Defaults.h
@@ -1,8 +1,9 @@
 // Copyright (c) 2024 Jay Prall
 // SPDX-License-Identifier: MIT
 
-// Defaults.h : Centralized constants for array sizes and other shared defaults.
-//
+// Defaults.h : Centralized application defaults used by multiple subsystems.
+// Stores persistent settings and default color/state values. UI layout details and
+// dialog‑specific constants are intentionally kept out of this header.
 
 #pragma once
 


### PR DESCRIPTION
- replace legacy MFC boilerplate headers with accurate, descriptive module summaries
- update ColorCop.cpp header to reflect initialization and single‑instance logic
- update ColorCopDlg.cpp header to describe full UI responsibilities
- remove obsolete AFX/ClassWizard comment blocks
- replace misleading comments (system‑menu handler, OnPaint) with clear explanations
- improve Defaults.h header to clarify scope of global defaults