### PR TITLE
chore(format): replace clang-format config with MFC-safe rules and di…

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,53 @@
-BraceWrapping:
-  AfterControlStatement: true
-  BeforeElse: true
+BasedOnStyle: Microsoft
 
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
 
+# Preserve existing brace placement (K&R / Attach)
+BreakBeforeBraces: Attach
+
+# Includes: do NOT reorder, align, or regroup
+SortIncludes: false
+IncludeBlocks: Preserve
+AlignEscapedNewlines: DontAlign
+
+# Preserve MFC macro blocks
+MacroBlockBegin: "^BEGIN_"
+MacroBlockEnd: "^END_"
+
+# Avoid aggressive wrapping that causes diff churn
+ColumnLimit: 0
+AllowShortIfStatementsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: false
+
+# Pointer/reference spacing consistent with MSVC style
+PointerAlignment: Left
+SpaceAfterCStyleCast: true
+
+# Avoid rewriting constructor initializer lists
+BreakConstructorInitializers: BeforeColon
+
+# Avoid messing with case labels
+IndentCaseLabels: false
+
+# Do NOT reflow comments
+ReflowComments: false
+
+# Preprocessor formatting: leave indentation untouched
+IndentPPDirectives: None
+PPIndentWidth: 0
+
+# Do NOT align comments or declarations
+AlignTrailingComments: false
+AlignConsecutiveDeclarations: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveMacros: None
+
+# Keep access specifiers exactly where they are
+AccessModifierOffset: 0
+
+# Preserve blank lines
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,31 @@
 {
-    "editor.unicodeHighlight.nonBasicASCII": true,
-    "editor.unicodeHighlight.ambiguousCharacters": true,
-    "editor.unicodeHighlight.invisibleCharacters": true,
-    "editor.unicodeHighlight.allowedCharacters": {}
+  "C_Cpp.vcFormat.enabled": false,
+  "C_Cpp.formatting": "clangFormat",
+  "editor.defaultFormatter": "ms-vscode.cpptools",
+"[cpp]": {
+    "editor.formatOnSave": true,
+    "editor.autoIndent": "none",
+    "editor.formatOnType": false,
+    "editor.formatOnPaste": false
+},
+"[c]": {
+    "editor.formatOnSave": true,
+    "editor.autoIndent": "none",
+    "editor.formatOnType": false,
+    "editor.formatOnPaste": false
+},
+  "editor.unicodeHighlight.nonBasicASCII": true,
+  "editor.unicodeHighlight.ambiguousCharacters": true,
+  "editor.unicodeHighlight.invisibleCharacters": true,
+  "editor.unicodeHighlight.allowedCharacters": {},
+
+  "[json]": {
+    "editor.formatOnSave": false
+  },
+  "[xml]": {
+    "editor.formatOnSave": false
+  },
+  "[plaintext]": {
+    "editor.formatOnSave": false
+  }
 }

--- a/format.sh
+++ b/format.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-find . \
-  -type f \( -name '*.cpp' -o -name '*.h' \) \
-  -exec clang-format -i --fallback-style=none {} +
-


### PR DESCRIPTION
…sable VS Code auto-indent

- Replace minimal .clang-format with consolidated Microsoft/MFC-safe configuration to prevent churn in legacy headers (no include alignment, no comment alignment, no access-specifier indentation, no PP indentation changes, no brace movement).
- Update .vscode/settings.json to disable VCFormat and all VS Code auto-indentation so only clang-format controls formatting.
- Add Unicode highlight settings and disable format-on-save for non-C++ file types.
- Remove format.sh since formatting is now handled exclusively via clang-format through VS Code.