### PR TITLE
fix(color-modes): remove incorrect XOR checks and centralize mode swi…

### DIFF
--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -2619,128 +2619,96 @@ void CColorCopDlg::OnUpdatePopupModeClarionhex(CCmdUI* pCmdUI) {
 
 void CColorCopDlg::OnPopupModeRgbfloat() {
     SetStatusBarText(IDS_MODE_RGBFLOAT, 1);
-    if (m_Appflags ^ ModeHTML) {
-        m_Appflags &= ~ModeHTML;
-        m_Appflags &= ~ModeDelphi;
-        m_Appflags &= ~ModePowerBuilder;
-        m_Appflags &= ~ModeVisualBasic;
-        m_Appflags &= ~ModeVisualC;
-        m_Appflags |= RGBFLOAT;  // rgb float
-        m_Appflags &= ~RGBINT;
-        m_Appflags &= ~ModeClarion;
-    }
+
+    // Clear all other modes
+    m_Appflags &= ~kAllColorModes;
+    // Set RGB float mode
+    m_Appflags |= RGBFLOAT;
+
     OnconvertRGB();
     OnCopytoclip();
 }
 
 void CColorCopDlg::OnPopupModeRgbint() {
     SetStatusBarText(IDS_MODE_RGBINT, 1);
-    if (m_Appflags ^ ModeHTML) {
-        m_Appflags &= ~ModeHTML;
-        m_Appflags &= ~ModeDelphi;
-        m_Appflags &= ~ModePowerBuilder;
-        m_Appflags &= ~ModeVisualBasic;
-        m_Appflags &= ~ModeVisualC;
-        m_Appflags &= ~RGBFLOAT;
-        m_Appflags |= RGBINT;  // rgb int
-        m_Appflags &= ~ModeClarion;
-    }
+
+    // Clear all other modes
+    m_Appflags &= ~kAllColorModes;
+    // Set RGB integer mode
+    m_Appflags |= RGBINT;
+
     OnconvertRGB();
     OnCopytoclip();
 }
 
 void CColorCopDlg::OnViewHtmlhexmode() {
     SetStatusBarText(IDS_MODE_HTML, 1);
-    if (m_Appflags ^ ModeHTML) {
-        m_Appflags |= ModeHTML;  // HTML ON
-        m_Appflags &= ~ModeDelphi;
-        m_Appflags &= ~ModePowerBuilder;
-        m_Appflags &= ~ModeVisualBasic;
-        m_Appflags &= ~ModeVisualC;
-        m_Appflags &= ~RGBFLOAT;
-        m_Appflags &= ~RGBINT;
-        m_Appflags &= ~ModeClarion;
-    }
+
+    // Clear all other modes
+    m_Appflags &= ~kAllColorModes;
+    // Set HTML mode
+    m_Appflags |= ModeHTML;
+
     OnconvertRGB();
     OnCopytoclip();
 }
 
 void CColorCopDlg::OnOptionsDelphimode() {
     SetStatusBarText(IDS_MODE_DELPHI, 1);
-    if (m_Appflags ^ ModeDelphi) {
-        m_Appflags &= ~ModeHTML;
-        m_Appflags |= ModeDelphi;  // Delphi ON
-        m_Appflags &= ~ModePowerBuilder;
-        m_Appflags &= ~ModeVisualBasic;
-        m_Appflags &= ~ModeVisualC;
-        m_Appflags &= ~RGBFLOAT;
-        m_Appflags &= ~RGBINT;
-        m_Appflags &= ~ModeClarion;
-    }
+
+    // Clear all other modes
+    m_Appflags &= ~kAllColorModes;
+    // Set Delphi mode
+    m_Appflags |= ModeDelphi;
+
     OnconvertRGB();
     OnCopytoclip();
 }
 
 void CColorCopDlg::OnPopupHexmodePowerbuilder() {
     SetStatusBarText(IDS_MODE_POWERBUILDER, 1);
-    if (m_Appflags ^ ModePowerBuilder) {
-        m_Appflags &= ~ModeHTML;
-        m_Appflags &= ~ModeDelphi;
-        m_Appflags |= ModePowerBuilder;  // PowerBuilder ON
-        m_Appflags &= ~ModeVisualBasic;
-        m_Appflags &= ~ModeVisualC;
-        m_Appflags &= ~RGBFLOAT;
-        m_Appflags &= ~RGBINT;
-        m_Appflags &= ~ModeClarion;
-    }
+
+    // Clear all other modes
+    m_Appflags &= ~kAllColorModes;
+    // Set Powerbuilder mode
+    m_Appflags |= ModePowerBuilder;
+
     OnconvertRGB();
     OnCopytoclip();
 }
 
 void CColorCopDlg::OnPopupModeVisualbasichex() {
     SetStatusBarText(IDS_MODE_VISUALB, 1);
-    {
-        m_Appflags &= ~ModeHTML;
-        m_Appflags &= ~ModeDelphi;
-        m_Appflags &= ~ModePowerBuilder;
-        m_Appflags |= ModeVisualBasic;  // VisualBasic ON
-        m_Appflags &= ~ModeVisualC;
-        m_Appflags &= ~RGBFLOAT;
-        m_Appflags &= ~RGBINT;
-        m_Appflags &= ~ModeClarion;
-    }
+
+    // Clear all other modes
+    m_Appflags &= ~kAllColorModes;
+    // Set Visual Basic mode
+    m_Appflags |= ModeVisualBasic;
+
     OnconvertRGB();
     OnCopytoclip();
 }
 
 void CColorCopDlg::OnPopupModeVisualchex() {
     SetStatusBarText(IDS_MODE_VISUALC, 1);
-    if (m_Appflags ^ ModeVisualC) {
-        m_Appflags &= ~ModeHTML;
-        m_Appflags &= ~ModeDelphi;
-        m_Appflags &= ~ModePowerBuilder;
-        m_Appflags &= ~ModeVisualBasic;
-        m_Appflags |= ModeVisualC;  // VisualC ON
-        m_Appflags &= ~RGBFLOAT;
-        m_Appflags &= ~RGBINT;
-        m_Appflags &= ~ModeClarion;
-    }
+
+    // Clear all other modes
+    m_Appflags &= ~kAllColorModes;
+    // Set Visual C++ mode
+    m_Appflags |= ModeVisualC;
+
     OnconvertRGB();
     OnCopytoclip();
 }
 
 void CColorCopDlg::OnPopupModeClarionhex() {
     SetStatusBarText(IDS_MODE_CLARION, 1);
-    if (m_Appflags ^ ModeClarion) {
-        m_Appflags &= ~ModeHTML;
-        m_Appflags &= ~ModeDelphi;
-        m_Appflags &= ~ModePowerBuilder;
-        m_Appflags &= ~ModeVisualBasic;
-        m_Appflags &= ~ModeVisualC;
-        m_Appflags &= ~RGBFLOAT;
-        m_Appflags &= ~RGBINT;
-        m_Appflags |= ModeClarion;  // Clarion ON
-    }
+
+    // Clear all other modes
+    m_Appflags &= ~kAllColorModes;
+    // Set Clarion mode
+    m_Appflags |= ModeClarion;
+
     OnconvertRGB();
     OnCopytoclip();
 }

--- a/ColorCopDlg.h
+++ b/ColorCopDlg.h
@@ -21,6 +21,18 @@ constexpr double RGB_MAX_D         = 255.0;          // double version of 255
 #define BMP_FILE "\\Color_Cop.bmp"
 #define BMP_FILE_DIR "\\ColorCop"
 
+// Centralized list of all color output modes. Update this mask whenever a new
+// mode is added so mode‑switch handlers remain consistent and future‑proof.
+static constexpr uint32_t kAllColorModes =
+    ModeHTML |
+    ModeDelphi |
+    ModePowerBuilder |
+    ModeVisualBasic |
+    ModeVisualC |
+    ModeClarion |
+    RGBFLOAT |
+    RGBINT;
+
 class CSystemTray;
 
 class CColorCopDlg : public CDialog {


### PR DESCRIPTION
…tching logic

Replaced all `if (m_Appflags ^ ModeX)` conditions with a unified and correct mode-switching approach. Introduced `kAllColorModes` to represent all mutually-exclusive output modes, and updated every mode handler to clear this mask before enabling the selected mode. This eliminates long-standing XOR logic bugs, ensures consistent behavior across all color modes, and improves maintainability.