### PR TITLE
feat(colorcop): normalize numeric types, remove narrowing, and centra…

### DIFF
--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -35,8 +35,6 @@ constexpr int kMinZoom = 1;
 constexpr int kMaxZoom = 16;
 // Magnifier button size in pixels (square)
 constexpr int kMagButtonSize = 11;
-// Default zoom level for the magnifier (5x)
-constexpr int kDefaultMagLevel = 5;
 
 #include "AboutDlg.h"
 
@@ -64,8 +62,6 @@ CColorCopDlg::CColorCopDlg(CWnd* pParent /*=NULL*/)
       m_iSamplingOffset(0),
       WinLocX(0),
       WinLocY(0),
-      m_MagLevel(kDefaultMagLevel),
-      m_FloatPrecision(0),
       hBitmap(nullptr),
       hBitmapClip(nullptr),
       hZoomBitmap(nullptr),
@@ -330,7 +326,6 @@ BOOL CColorCopDlg::OnInitDialog() {
     } else {
         ChangeColorSpace(true);
     }
-    m_FloatPrecision = 2;
     OnconvertRGB();
     CalcColorPal();
     OnCopytoclip();
@@ -2212,13 +2207,12 @@ void CColorCopDlg::OnPopupColorConverttograyscale() {
         // all receive the same value, producing a grayscale color.
         //
 
-        // Compute channel extrema.
-        uint16_t Max = std::max({m_Reddec, m_Greendec, m_Bluedec});
-        uint16_t Min = std::min({m_Reddec, m_Greendec, m_Bluedec});
+        // Compute channel extrema in int.
+        const int Max = std::max({m_Reddec, m_Greendec, m_Bluedec});
+        const int Min = std::min({m_Reddec, m_Greendec, m_Bluedec});
 
-        // Compute grayscale lightness safely in int, then narrow explicitly.
-        const int tmpL = (static_cast<int>(Min) + static_cast<int>(Max)) / 2;
-        uint16_t L = static_cast<std::uint16_t>(tmpL);
+        // Compute grayscale lightness in int.
+        const int L = (Min + Max) / 2;
 
         // Apply grayscale value to all channels.
         m_Reddec = L;
@@ -2271,9 +2265,9 @@ void CColorCopDlg::TestForWebsafe() {
         m_oldColorSaved = true;
 
         // Backup the actual RGB values before snapping
-        m_OldRed = static_cast<std::uint8_t>(m_Reddec);
-        m_OldGreen = static_cast<std::uint8_t>(m_Greendec);
-        m_OldBlue = static_cast<std::uint8_t>(m_Bluedec);
+        m_OldRed = m_Reddec;
+        m_OldGreen = m_Greendec;
+        m_OldBlue = m_Bluedec;
 
         // Snap each component to the nearest web‑safe value
         m_Reddec = DecimaltoWebsafe(m_Reddec);

--- a/ColorCopDlg.h
+++ b/ColorCopDlg.h
@@ -44,9 +44,10 @@ class CColorCopDlg : public CDialog {
     int m_Appflags;
     int m_iSamplingOffset;
 
-    int WinLocX, WinLocY;
-    int16_t m_MagLevel;
-    int16_t m_FloatPrecision;
+    int WinLocX;
+    int WinLocY;
+    int m_MagLevel = kDefaultMagLevel;
+    int m_FloatPrecision = kDefaultFloatPrecision;
 
     HBITMAP hBitmap, hBitmapClip, hZoomBitmap;
 
@@ -109,9 +110,9 @@ class CColorCopDlg : public CDialog {
 
     HACCEL m_hAcceleratorTable;
 
-    std::uint8_t m_OldRed{};    // original red value before snapping to websafe
-    std::uint8_t m_OldGreen{};  // original green value before snapping to websafe
-    std::uint8_t m_OldBlue{};   // original blue value before snapping to websafe
+    int m_OldRed = 0;    // original red value before snapping to websafe
+    int m_OldGreen = 0;  // original green value before snapping to websafe
+    int m_OldBlue = 0;   // original blue value before snapping to websafe
 
     BOOL m_oldColorSaved;  // whether we have a saved pre‑snap color to restore from
     BOOL m_isEyedropping;
@@ -131,7 +132,8 @@ class CColorCopDlg : public CDialog {
     int smWidth;
     int lgHeight;
     int lgWidth;
-    unsigned int m_nwide, m_ntall;
+    int m_nwide;
+    int m_ntall;
 
     // color palette stuff
     double r, g, b;

--- a/Defaults.h
+++ b/Defaults.h
@@ -28,3 +28,8 @@ constexpr COLORREF kDefaultColorHistory[kHistoryCount] = {
 constexpr COLORREF kDefaultSeedColor = RGB(171, 208, 188);
 
 constexpr COLORREF kDefaultCustomColor = 0x00FFFFFF;
+
+// Default zoom level for the magnifier (5x)
+constexpr int kDefaultMagLevel = 5;
+// Default float precision for RGB float mode (2 decimal places)
+constexpr int kDefaultFloatPrecision = 2;


### PR DESCRIPTION
…lize defaults

Replace uint16_t and uint8_t RGB intermediates with int to eliminate narrowing and simplify arithmetic

Move m_MagLevel and m_FloatPrecision defaults into the header and remove redundant constructor and OnInitDialog initialization

Convert m_OldRed, m_OldGreen, and m_OldBlue to int to match UI RGB types and remove unnecessary casts

Add kDefaultFloatPrecision constant for clarity and consistency

Convert m_nwide and m_ntall from unsigned int to int for consistency with other UI-bound numeric fields

Clean up grayscale conversion logic to use int throughout