### PR TITLE
fix: use CString::GetString() in TRACE calls

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,9 +47,6 @@ AlignConsecutiveDeclarations: None
 AlignConsecutiveAssignments: None
 AlignConsecutiveMacros: None
 
-# Keep access specifiers exactly where they are
-AccessModifierOffset: 0
-
 # Preserve blank lines
 KeepEmptyLinesAtTheStartOfBlocks: true
 MaxEmptyLinesToKeep: 2

--- a/ColorCop.cpp
+++ b/ColorCop.cpp
@@ -162,7 +162,7 @@ BOOL CColorCopApp::InitApplication() {
     CString strInitFile = settingsFolder + INI_FILE;  // "\Color_Cop.dat"
 
     TRACE(_T("Portable mode: %d\n"), m_PortableMode);
-    TRACE(_T("INI path: %s\n"), strInitFile);
+    TRACE(_T("INI path: %s\n"), strInitFile.GetString());
 
     CFile file;
     if (file.Open(strInitFile, CFile::modeRead)) {
@@ -214,7 +214,8 @@ void CColorCopApp::CloseApplication() {
     CString strInitFile = settingsFolder + INI_FILE;
 
     TRACE(_T("Portable mode: %d\n"), m_PortableMode);
-    TRACE(_T("INI path: %s\n"), strInitFile);
+    TRACE(_T("INI path: %s\n"), strInitFile.GetString());
+
 
     if (!m_PortableMode) {
         // Ensure folder exists in installed mode
@@ -245,8 +246,9 @@ void CColorCopApp::Serialize(CArchive& ar) {
 
             ar << dlg.m_iSamplingOffset;
         } catch (CArchiveException& e) {
-            TRACE("Archive exception caught. Cause = %d, File = %s\n", e.m_cause,
-                  e.m_strFileName ? e.m_strFileName : "(unknown)");
+            TRACE(_T("Archive exception caught. Cause = %d, File = %s\n"),
+                  e.m_cause,
+                  e.m_strFileName.IsEmpty() ? _T("(unknown)") : e.m_strFileName.GetString());
             AfxMessageBox(IDS_ERROR_SAVING);
         }
     } else {
@@ -268,8 +270,9 @@ void CColorCopApp::Serialize(CArchive& ar) {
             }
             ar >> dlg.m_iSamplingOffset;
         } catch (CArchiveException& e) {
-            TRACE("Archive exception caught. Cause = %d, File = %s\n", e.m_cause,
-                  e.m_strFileName ? e.m_strFileName : "(unknown)");
+            TRACE(_T("Archive exception caught. Cause = %d, File = %s\n"),
+                  e.m_cause,
+                  e.m_strFileName.IsEmpty() ? _T("(unknown)") : e.m_strFileName.GetString());
             AfxMessageBox(IDS_ERROR_LOADING);
         }
     }

--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -391,7 +391,7 @@ bool CColorCopDlg::LoadPersistentVariables() {
     CString strBMPFile = pApp->GetSettingsFolder();
     strBMPFile += BMP_FILE;
 
-    TRACE(_T("BMP path: %s\n"), strBMPFile);
+    TRACE(_T("BMP path: %s\n"), strBMPFile.GetString());
 
     // Load bitmap from file
     hBitmap = reinterpret_cast<HBITMAP>(
@@ -2066,7 +2066,7 @@ void CColorCopDlg::OnDestroy() {
     strBMPFile += BMP_FILE;
 
     TRACE(_T("Portable mode: %d\n"), m_PortableMode);
-    TRACE(_T("BMP path: %s\n"), strBMPFile);
+    TRACE(_T("BMP path: %s\n"), strBMPFile.GetString());
 
     HWND curwindowhwnd = ::GetForegroundWindow();
 


### PR DESCRIPTION
Replace direct CString usage in TRACE with CString::GetString() to ensure correct %s formatting and Unicode handling. Update archive-exception TRACE calls to use _T() format, check e.m_strFileName.IsEmpty() and print a "(unknown)" fallback. Remove AccessModifierOffset from .clang-format and preserve existing blank-line settings. Minor whitespace adjustment in CloseApplication.