### PR TITLE
chore(ci): remove push and manual triggers to prevent lint running twice

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,8 @@
 name: Lint
 
 on:
-  push:
   pull_request:
-  workflow_dispatch:
+
 permissions:
   contents: read
 


### PR DESCRIPTION
- drop `push` trigger so PRs no longer receive duplicate lint checks