### PR TITLE
fix: use AdjustWindowRectEx to compute collapsed size

### DIFF
--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -508,15 +508,19 @@ void CColorCopDlg::SetupWindowRects() {
     lgWidth = CCopRect.right - CCopRect.left;
     lgHeight = CCopRect.bottom - CCopRect.top;
 
-    // small sizes
-    smWidth = (exprect.right - CCopRect.left) + kMagButtonSize;
-    smHeight = (exprect.bottom - CCopRect.top) + kMagButtonSize;
+    int collapsedClientWidth = exprect.right;
+    int collapsedClientHeight = exprect.bottom;
+
+    RECT collapsedRect = {0, 0, collapsedClientWidth, collapsedClientHeight};
+    AdjustWindowRectEx(&collapsedRect, GetStyle(), FALSE, GetExStyle());
+
+    smWidth = collapsedRect.right - collapsedRect.left + 14;
+    smHeight = collapsedRect.bottom - collapsedRect.top + 14;
 
     // Setup magnify plus level rect
     CWnd::GetDlgItem(IDC_MAG_PLUS, &temphandle);
     ::GetWindowRect(temphandle, &magplus);
     CWnd::ScreenToClient(&magplus);
-
 
     magplus.right = magplus.left + kMagButtonSize;
     magplus.bottom = magplus.top + kMagButtonSize;


### PR DESCRIPTION
Replace ad-hoc small-size computation with a proper AdjustWindowRectEx-based calculation. The code now builds a collapsed client RECT from exprect, adjusts it for the current window style/exstyle, and derives smWidth/smHeight from the adjusted rect plus 14px padding (replacing the previous offsets that referenced CCopRect and kMagButtonSize). This ensures the small window dimensions account for non-client area and style differences.