### PR TITLE
refactor(colorcop): replace RangeCheck with std::clamp and remove leg…

### DIFF
--- a/ColorCopDlg.cpp
+++ b/ColorCopDlg.cpp
@@ -2873,16 +2873,14 @@ BOOL CColorCopDlg::OnMouseWheel(UINT nFlags, int16_t zDelta, CPoint pt) {
 
     if (curfocus == GetDlgItem(IDC_RED)) {  // red has focus
         m_Reddec += zDelta / WHEEL_DELTA * offset;
-        m_Reddec = RangeCheck(m_Reddec);
+        m_Reddec = std::clamp(m_Reddec, RGB_MIN, RGB_MAX);
 
     } else if (curfocus == GetDlgItem(IDC_GREEN)) {  // green has focus
         m_Greendec += zDelta / WHEEL_DELTA * offset;
-        m_Greendec = RangeCheck(m_Greendec);
-
+        m_Greendec = std::clamp(m_Greendec, RGB_MIN, RGB_MAX);
     } else if (curfocus == GetDlgItem(IDC_BLUE)) {  // blue has focus
         m_Bluedec += zDelta / WHEEL_DELTA * offset;
-        m_Bluedec = RangeCheck(m_Bluedec);
-
+        m_Bluedec = std::clamp(m_Bluedec, RGB_MIN, RGB_MAX);
     } else {          // there is focus, but it's not on either the Red,
         return TRUE;  // Green, or Blue edit controls -> jump out
     }
@@ -2893,22 +2891,6 @@ BOOL CColorCopDlg::OnMouseWheel(UINT nFlags, int16_t zDelta, CPoint pt) {
     OnCopytoclip();
 
     return CDialog::OnMouseWheel(nFlags, zDelta, pt);
-}
-
-int CColorCopDlg::RangeCheck(int icolorval) {
-    // this function ensures that the user doesn't use the mouse wheel to
-    // make a color decimal < 0 or > 255
-
-    if (icolorval > 255) {
-        // go right around to 0 or 1
-        return (icolorval % 256);
-    } else if (icolorval < 0) {
-        // roll around to 255 or 254
-        return (256 - std::abs(icolorval));
-    } else {
-        // it's valid -- leave it alone
-        return (icolorval);
-    }
 }
 
 void CColorCopDlg::OnTimer(UINT nIDEvent) {

--- a/ColorCopDlg.h
+++ b/ColorCopDlg.h
@@ -208,7 +208,6 @@ class CColorCopDlg : public CDialog {
     bool AveragePixelArea(HDC hdc, int* m_Reddec, int* m_Greendec, int* m_Bluedec, CPoint point);
     void SetupStatusBar();
     void SetStatusBarText(LPCTSTR statusText);
-    int RangeCheck(int icolorval);
     void AdvanceColorHistory();
     void GetHistoryColor(int Cindex);
     HBITMAP CopyBitmap(HBITMAP hBitmapSrc);


### PR DESCRIPTION
…acy wrap-around helper

Replaces all remaining RangeCheck() calls in OnMouseWheel() with std::clamp(RGB_MIN, RGB_MAX) to ensure consistent clamping behavior across all RGB input paths. Removes the obsolete RangeCheck() function from both ColorCopDlg.cpp and ColorCopDlg.h, eliminating legacy wrap‑around logic that is no longer used anywhere in the codebase.