### PR TITLE
feat(security): enable CFG and SafeSEH in Win32 build

### DIFF
--- a/ColorCop.vcxproj
+++ b/ColorCop.vcxproj
@@ -63,6 +63,7 @@
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <SDLCheck>true</SDLCheck>
       <SpectreMitigation>Spectre</SpectreMitigation>
     </ClCompile>
@@ -77,6 +78,8 @@
       <OptimizeReferences>true</OptimizeReferences>
       <DynamicBase>true</DynamicBase>      <!-- ASLR -->
       <NxCompat>true</NxCompat>            <!-- DEP -->
+      <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -95,6 +98,7 @@
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <SDLCheck>true</SDLCheck>
       <SpectreMitigation>Spectre</SpectreMitigation>
     </ClCompile>
@@ -109,6 +113,8 @@
       <AdditionalDependencies>Htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DynamicBase>true</DynamicBase>      <!-- ASLR -->
       <NxCompat>true</NxCompat>            <!-- DEP -->
+      <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Add Control Flow Guard (CFG) to both ClCompile and Link steps, ensuring object files and the final executable are fully protected. Enable SafeSEH in the linker for Win32 to harden structured exception handling against hijacking.

These mitigations modernize the security posture of the ColorCop Win32/MFC build without altering runtime behavior.