### PR TITLE
feat(help): modernize help system, move accelerator loading, and clea…

### DIFF
--- a/ColorCop/ColorCop.cpp
+++ b/ColorCop/ColorCop.cpp
@@ -26,7 +26,6 @@ BEGIN_MESSAGE_MAP(CColorCopApp, CWinApp)
     // NOTE - the ClassWizard will add and remove mapping macros here.
     //    DO NOT EDIT what you see in these blocks of generated code!
     //}}AFX_MSG // NOLINT(whitespace/comments)
-    ON_COMMAND(ID_HELP, CWinApp::OnHelp)
 END_MESSAGE_MAP()
 
 /////////////////////////////////////////////////////////////////////////////

--- a/ColorCop/ColorCop.rc
+++ b/ColorCop/ColorCop.rc
@@ -131,7 +131,7 @@ BEGIN
     EDITTEXT        IDC_YELLOW,73,33,29,12,ES_CENTER | ES_AUTOHSCROLL
     CONTROL "", IDC_STATUSBAR, "msctls_statusbar32",
             WS_CHILD | WS_VISIBLE | SBARS_SIZEGRIP,
-            0, 146, 132, 20 
+            0, 146, 132, 20
 END
 
 
@@ -273,7 +273,7 @@ BEGIN
             MENUITEM "Magnify while Eyedropping",   ID_POPUP_OPTIONS_MAGNIFYWHILEEYEDROPPING, CHECKED
             MENUITEM "Use Cross Hair Cursor",       ID_POPUP_OPTIONS_USECROSSHAIRCURSOR
             MENUITEM "Put cursor over Eyedropper on Startup", ID_POPUP_OPTIONS_STARTCURSORONEYEDROPPER
-        
+
             POPUP "&Theme"
     BEGIN
         MENUITEM "System", ID_THEME_SYSTEM
@@ -338,6 +338,7 @@ BEGIN
     "Z",            ID_COLOR_RANDOM,        VIRTKEY, CONTROL, NOINVERT
     "[",            ID_FLOATDOWN,           ASCII,  ALT, NOINVERT
     "]",            ID_FLOATUP,             ASCII,  ALT, NOINVERT
+    VK_F1,          ID_POPUP_APPLICATION_HELP, VIRTKEY, NOINVERT
 END
 
 

--- a/ColorCop/ColorCopDlg.cpp
+++ b/ColorCop/ColorCopDlg.cpp
@@ -17,7 +17,6 @@
 
 // Windows SDK headers (explicit APIs used in this file)
 #include <commctrl.h>
-#include <htmlhelp.h>
 
 // C++ standard library headers
 #include <algorithm>  // std::min, std::max
@@ -406,6 +405,13 @@ BOOL CColorCopDlg::OnInitDialog() {
 
     ApplyTheme();
 
+    // Load accelerator resource once MFC instance handle and window are valid
+    if (m_hAcceleratorTable == nullptr) {
+        m_hAcceleratorTable =
+            ::LoadAccelerators(AfxGetInstanceHandle(),
+                                MAKEINTRESOURCE(IDR_COLORCOP_ACCEL));
+    }
+
     return FALSE;  // return TRUE unless you set the focus to a control
 }
 
@@ -449,11 +455,6 @@ void CColorCopDlg::OnDrawItem(int nIDCtl, LPDRAWITEMSTRUCT lpDIS) {
 }
 
 void CColorCopDlg::SetupSystemMenu() {
-    // Load accelerator resource
-    m_hAcceleratorTable =
-        ::LoadAccelerators(AfxGetInstanceHandle(),
-                           MAKEINTRESOURCE(IDR_COLORCOP_ACCEL));
-
     ASSERT((IDM_ABOUTBOX & 0xFFF0) == IDM_ABOUTBOX);
 
     CMenu* pSysMenu = GetSystemMenu(FALSE);
@@ -1993,21 +1994,14 @@ BOOL CColorCopDlg::PreTranslateMessage(MSG* pMsg) {
     static int repeat = 1;  // repeat key counter
 
     // Forward mouse messages to tooltip control
-    if (m_ToolTip.GetSafeHwnd()) {
+    if (m_ToolTip.GetSafeHwnd() &&
+        ::IsWindow(m_ToolTip.GetSafeHwnd())) {
         m_ToolTip.RelayEvent(pMsg);
     }
 
     // Accelerator handling
-    if (m_hAcceleratorTable) {
+    if (m_hAcceleratorTable && m_hWnd != NULL && ::IsWindow(m_hWnd)) {
         if (::TranslateAccelerator(m_hWnd, m_hAcceleratorTable, pMsg)) {
-            return TRUE;
-        }
-    }
-
-    // F1 help (0x4D = WM_HELP)
-    if (pMsg->message == 0x4d) {
-        if (GetKeyState(VK_SHIFT) >= 0) {
-            ::HtmlHelp(NULL, _T("ColorCop.chm"), HH_DISPLAY_TOPIC, 0);
             return TRUE;
         }
     }
@@ -3040,7 +3034,16 @@ void CColorCopDlg::OnTimer(UINT nIDEvent) {
 }
 
 void CColorCopDlg::OnPopupApplicationHelp() {
-    ::HtmlHelp(NULL, _T("ColorCop.chm"), HH_DISPLAY_TOPIC, 0);
+    CString helpPath;
+    GetModuleFileName(NULL, helpPath.GetBufferSetLength(MAX_PATH), MAX_PATH);
+    helpPath.ReleaseBuffer();
+    PathRemoveFileSpec(helpPath.GetBuffer());
+    helpPath.ReleaseBuffer();
+    helpPath += _T("\\ColorCop.chm");
+    // Use ShellExecute with hh.exe instead of HtmlHelp:
+    // - HtmlHelp is deprecated and unreliable on modern Windows
+    // - Ensures the .chm opens correctly regardless of installation path
+    ShellExecute(NULL, _T("open"), _T("hh.exe"), helpPath, NULL, SW_SHOWNORMAL);
 }
 
 void CColorCopDlg::OnPopupColorDetectwebsafe() {


### PR DESCRIPTION
…n up message handling

- Remove legacy ON_COMMAND(ID_HELP, CWinApp::OnHelp) mapping
- Add F1 accelerator (VK_F1 → ID_POPUP_APPLICATION_HELP) to .rc
- Replace HtmlHelp() with ShellExecute(hh.exe) for reliable CHM launching
- Resolve help file path dynamically relative to module directory
- Move accelerator loading to OnInitDialog() to ensure valid window handle
- Remove redundant accelerator load from SetupSystemMenu()
- Remove obsolete WM_HELP (0x4D) manual handling in PreTranslateMessage()
- Add IsWindow() guards for tooltip and accelerator translation
- Minor whitespace and formatting fixes in .rc and source files