### PR TITLE
feat(manifest): embed app.manifest and modernize DPI/compat settings

### DIFF
--- a/ColorCop/ColorCop.vcxproj
+++ b/ColorCop/ColorCop.vcxproj
@@ -83,6 +83,9 @@
       <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
       <ControlFlowGuard>Guard</ControlFlowGuard>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)app.manifest</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -120,6 +123,10 @@
       <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
       <ControlFlowGuard>Guard</ControlFlowGuard>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)app.manifest</AdditionalManifestFiles>
+    </Manifest>
+
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AboutDlg.cpp" />

--- a/ColorCop/app.manifest
+++ b/ColorCop/app.manifest
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 
-  <!-- Identity -->
   <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="*"
@@ -9,48 +8,31 @@
     type="win32"
   />
 
-  <!-- UAC -->
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>
-        <requestedExecutionLevel
-          level="asInvoker"
-          uiAccess="false"
-        />
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
       </requestedPrivileges>
     </security>
   </trustInfo>
 
-  <!-- Declare support for Windows 7 through Windows 11 to prevent legacy shims -->
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- Windows 7 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-      <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-      <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-      <!-- Windows 11 -->
       <supportedOS Id="{d782cc4f-4cf3-45da-a0f3-3e8e3cbbf0d5}"/>
     </application>
   </compatibility>
 
-  <!-- DPI Awareness -->
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings>
-      <!-- Legacy DPI awareness (Vista → Win8.1) -->
+  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <asmv3:windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
 
-      <!-- Modern DPI awareness (Win10+) -->
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
-        PerMonitorV2
-      </dpiAwareness>
-    </windowsSettings>
-  </application>
-
-  <!-- Common Controls v6 -->
   <dependency>
     <dependentAssembly>
       <assemblyIdentity
@@ -65,3 +47,4 @@
   </dependency>
 
 </assembly>
+


### PR DESCRIPTION
Embed `app.manifest` into both Win32 Debug and Release builds using `<AdditionalManifestFiles>` so MSBuild correctly merges the manifest during linking. This ensures the final binary includes PerMonitorV2 DPI awareness, updated supportedOS GUIDs, and ComCtl32 v6.

Also cleaned up `app.manifest` by removing redundant comments, normalizing DPI declarations, and switching to the `asmv3:application` structure.