### PR TITLE
feat(winget): add initial WinGet manifest scaffolding for ColorCop

### DIFF
--- a/.github/winget/manifest/defaultLocale.yaml
+++ b/.github/winget/manifest/defaultLocale.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: JayPrall.ColorCop
+PackageVersion: 0.0.0
+PackageLocale: en-US
+Publisher: Jay Prall
+PackageName: Color Cop
+PackageUrl: https://github.com/ColorCop/ColorCop
+License: MIT
+ShortDescription: A Windows-based color picker utility built with Microsoft Foundation Classes (MFC).
+Moniker: colorcop
+
+Icons:
+  - IconUrl: https://colorcop.net/images/ccicon.png
+    IconType: Default
+

--- a/.github/winget/manifest/installer.yaml
+++ b/.github/winget/manifest/installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: JayPrall.ColorCop
+PackageVersion: 0.0.0
+
+Installers:
+  - Architecture: x86
+    InstallerType: exe
+    InstallerUrl: https://github.com/ColorCop/ColorCop/releases/download/v0.0.0/colorcop-setup.exe
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+
+ManifestType: installer
+ManifestVersion: 1.12.0
+

--- a/.github/winget/manifest/version.yaml
+++ b/.github/winget/manifest/version.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: JayPrall.ColorCop
+PackageVersion: 0.0.0
+DefaultLocale: en-US
+
+ManifestType: version
+ManifestVersion: 1.12.0
+


### PR DESCRIPTION
- Add defaultLocale.yaml with package metadata, moniker, and icon
- Add installer.yaml defining x86 EXE installer and placeholder SHA256
- Add version.yaml linking version and default locale
- All manifests use schema 1.12.0 and establish baseline package structure