### PR TITLE
refactor(math): replace kPi with std::numbers::pi and remove custom c…

### DIFF
--- a/ColorCop/ColorCopDlg.cpp
+++ b/ColorCop/ColorCopDlg.cpp
@@ -23,6 +23,7 @@
 #include <random>     // std::mt19937, std::uniform_int_distribution
 #include <cstdlib>    // strtoul, abs
 #include <cstring>    // memcpy
+#include <numbers>    // std::numbers::pi
 
 constexpr int WEBSAFE_STEP = 51;
 constexpr int RGB_MIN = 0;
@@ -1809,7 +1810,7 @@ void CColorCopDlg::OnMouseMove(UINT nFlags, CPoint point) {
             const double h = static_cast<double>(dy + 1);
 
             const double length = std::sqrt(w * w + h * h);
-            const double angle = std::atan2(h, w) * (180.0 / kPi);
+            const double angle = std::atan2(h, w) * (180.0 / std::numbers::pi);
 
             strStatus.LoadString(IDS_RELATIVE_POS);
             strStatus.Format(strStatus, dx, dy, length, angle);

--- a/ColorCop/pch.h
+++ b/ColorCop/pch.h
@@ -7,8 +7,8 @@
 // Platform / Windows configuration
 //------------------------------------------------------------------------------
 
-#define NOMINMAX              // Prevent Windows macros from breaking std::min/std::max
-#define WIN32_LEAN_AND_MEAN   // Exclude rarely-used Windows headers
+#define NOMINMAX             // Prevent Windows macros from breaking std::min/std::max
+#define WIN32_LEAN_AND_MEAN  // Exclude rarely-used Windows headers
 
 //------------------------------------------------------------------------------
 // Standard library
@@ -66,17 +66,14 @@
 constexpr int MULTIPIX_MIN = 1;
 constexpr int MULTIPIX_MAX = 15;
 
-// Prefer constexpr over macros for typed constants
-constexpr double kPi = 3.14159265358979323846;
-
 //------------------------------------------------------------------------------
 // MFC headers
 //------------------------------------------------------------------------------
 
-#include <afxwin.h>    // Core MFC components
-#include <afxext.h>    // Extensions (controls, OLE)
+#include <afxwin.h>  // Core MFC components
+#include <afxext.h>  // Extensions (controls, OLE)
 #ifndef _AFX_NO_AFXCMN_SUPPORT
-#include <afxcmn.h>    // Common controls
+#include <afxcmn.h>  // Common controls
 #endif
 
 //{{AFX_INSERT_LOCATION}} // NOLINT(whitespace/comments)


### PR DESCRIPTION
…onstant

Use the C++20 standard library constant std::numbers::pi for angle calculations and eliminate the redundant kPi definition from pch.h. This modernizes the math code, avoids duplicate sources of truth, and keeps the patch minimal and mechanical.