### PR TITLE
feat(ui): disable complementary palette for grayscale colors

### DIFF
--- a/ColorCop/ColorCopDlg.cpp
+++ b/ColorCop/ColorCopDlg.cpp
@@ -1153,20 +1153,17 @@ void CColorCopDlg::RGBtoHSL(double R, double G, double B) {
 
     // detect grayscale
     const bool isGray = (Diff <= HSL_EPSILON);
-
     if (isGray) {
-        // grayscale has no hue; neutral-axis complement computed but not stored
-        // (maps L in [0..1] back into the 0..255 RGB domain)
-        const uint16_t inv = static_cast<uint16_t>(RGB_MAX - (Light * RGB_MAX_D));
-        (void) inv;  // TODO(j4y): expose complement color in UI if a future feature requires it
-
-        // grayscale HSL values
+        // Grayscale has no hue; complement is undefined on the neutral axis.
         Sat = 0.0;
         Hue = 0.0;
 
+        m_HideComplement = true;
         return;
     }
 
+    // Chromatic colors have a valid hue → complement exists.
+    m_HideComplement = false;
 
     // find the Saturation
     if ((MaxNum == RGB_MAX) || (MinNum == 0)) {
@@ -1240,6 +1237,7 @@ void CColorCopDlg::DisplayColor() {
         insiderect.right = insiderect.left + m_nwide;
         insiderect.bottom = insiderect.top + m_ntall;
 
+        // Complementary palette (disabled placeholder for grayscale colors)
         for (int col = 0; col < 7; col++) {
             if (col) {
                 // not the top row
@@ -1248,7 +1246,9 @@ void CColorCopDlg::DisplayColor() {
                 insiderect.bottom += m_ntall;
             }
             for (int row = 0; row < 6; row++) {
-                pDC->FillSolidRect(insiderect, ColorPal[row][col]);
+                COLORREF fill =
+                    m_HideComplement ? RGB(192, 192, 192) : ColorPal[row][col];
+                pDC->FillSolidRect(insiderect, fill);
 
                 insiderect.right += m_nwide;
                 insiderect.left += m_nwide;

--- a/ColorCop/ColorCopDlg.h
+++ b/ColorCop/ColorCopDlg.h
@@ -165,8 +165,13 @@ class CColorCopDlg : public CDialog {
     int m_ntall;
 
     // color palette stuff
-    double r, g, b;
-    double Hue, Sat, Light;
+    double r;
+    double g;
+    double b;
+    double Hue;
+    double Sat;
+    double Light;
+    bool m_HideComplement = false;
 
     struct swatchStruct {
         double A;


### PR DESCRIPTION
Add m_HideComplement flag and update RGBtoHSL to mark grayscale colors as having no valid complement. DisplayColor now renders a disabled placeholder palette (neutral gray) instead of showing complementary colors when the selected color is grayscale. This improves clarity and prevents misleading complement output.