### PR TITLE
fix(bmp-save): eliminate GDI/DC leak, replace LocalAlloc, and harden …

### DIFF
--- a/ColorCop/ColorCopDlg.cpp
+++ b/ColorCop/ColorCopDlg.cpp
@@ -2277,17 +2277,26 @@ void CColorCopDlg::OnDestroy() {
     TRACE(_T("Portable mode: %d\n"), m_PortableMode);
     TRACE(_T("BMP path: %s\n"), strBMPFile.GetString());
 
-    HWND curwindowhwnd = ::GetForegroundWindow();
+    HWND curwindowhwnd = m_hWnd;
 
     if (hBitmap) {
         PBITMAPINFO MagBmpInfo = CreateBitmapInfoStruct(curwindowhwnd, hBitmap);
-        CreateBMPFile(curwindowhwnd, strBMPFile.GetBuffer(MAX_PATH), MagBmpInfo, hBitmap, ::GetDC(NULL));
+        if (!MagBmpInfo) {
+            // Failed to create bitmap info struct; log and exit gracefully
+            TRACE(_T("Failed to create bitmap info struct for saving bitmap.\n"));
+            CDialog::OnDestroy();
+            return;
+        }
+
+        WindowDC screenDC(NULL);
+        CreateBMPFile(curwindowhwnd, strBMPFile.GetBuffer(MAX_PATH), MagBmpInfo, hBitmap, screenDC);
 
         strBMPFile.ReleaseBuffer();
+        // Free BITMAPINFO allocated by CreateBitmapInfoStruct
+        HeapFree(GetProcessHeap(), 0, MagBmpInfo);
     }
 
     CDialog::OnDestroy();
-    return;
 }
 
 void CColorCopDlg::OnFileExit() {
@@ -3224,7 +3233,7 @@ PBITMAPINFO CColorCopDlg::CreateBitmapInfoStruct(HWND /*hwnd*/, HBITMAP hBmp) {
 
     const SIZE_T totalSize = headerSize + paletteSize;
 
-    PBITMAPINFO pbmi = static_cast<PBITMAPINFO>(LocalAlloc(LPTR, totalSize));
+    PBITMAPINFO pbmi = static_cast<PBITMAPINFO>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, totalSize));
     if (!pbmi) {
         return nullptr;
     }


### PR DESCRIPTION
…teardown path

Replaces deprecated LocalAlloc with HeapAlloc in CreateBitmapInfoStruct and adds correct HeapFree pairing in OnDestroy. Introduces WindowDC RAII wrapper to ensure screen DC is always released, preventing a GDI resource leak. Switches GetForegroundWindow to m_hWnd for stable teardown behavior and adds a null-check for BITMAPINFO allocation to avoid crashes during bitmap save.