### PR TITLE
refactor: migrate settings and bitmap path handling to std::filesystem

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -3,5 +3,7 @@ filter=-build/include
 # stop fighting clang-format
 filter=-whitespace/indent
 
+filter=-build/c++17
+
 # allow longer lines
 linelength=128

--- a/ColorCop/ColorCop.cpp
+++ b/ColorCop/ColorCop.cpp
@@ -9,6 +9,7 @@
 #include "ColorCop.h"
 #include "ColorCopDlg.h"
 #include "Defaults.h"
+#include <shlobj.h>  // SHGetKnownFolderPath, FOLDERID_LocalAppData
 
 #define INI_FILE _T("\\Color_Cop.dat")
 #define INI_FILE_DIR _T("\\ColorCop")
@@ -137,24 +138,25 @@ BOOL CColorCopApp::GetShellFolderPath(LPCTSTR pShellFolder, LPTSTR pShellPath) {
     }
 }
 
-CString CColorCopApp::GetSettingsFolder() {
-    CString path;
+std::filesystem::path CColorCopApp::GetSettingsFolder() {
     if (m_PortableMode) {
-        // Portable mode: store settings next to the EXE
-        TCHAR exePath[MAX_PATH] = {0};
-        GetModuleFileName(NULL, exePath, MAX_PATH);
-        PathRemoveFileSpec(exePath);
-        path = exePath;
-        return path;  // e.g. C:\Tools\ColorCop
+        // Portable mode → directory containing the EXE
+        wchar_t exePath[MAX_PATH];
+        GetModuleFileNameW(nullptr, exePath, MAX_PATH);
+        std::filesystem::path exe(exePath);
+        return exe.parent_path();
     }
 
-    // Installed mode: use LocalAppData\ColorCop
-    TCHAR buffer[MAX_PATH] = {0};
-    GetShellFolderPath(_T("Local AppData"), buffer);
-    path = buffer;
+    // Installed mode → LocalAppData\ColorCop
+    PWSTR raw = nullptr;
+    if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &raw))) {
+        std::filesystem::path localAppData(raw);
+        CoTaskMemFree(raw);
+        return localAppData / "ColorCop";
+    }
 
-    path += INI_FILE_DIR;  // "\ColorCop"
-    return path;           // e.g. C:\Users\...\AppData\Local\ColorCop
+    // Fallback if LocalAppData cannot be resolved
+    return std::filesystem::current_path() / "ColorCop";
 }
 
 void CColorCopApp::ClipOrCenterWindowToMonitor(HWND hwnd, UINT flags) {
@@ -175,8 +177,9 @@ BOOL CColorCopApp::InitApplication() {
         cmd.Find(_T("/portable")) != -1 || cmd.Find(_T("/p")) != -1) {
         m_PortableMode = true;
     }
-    CString settingsFolder = GetSettingsFolder();
-    CString strInitFile = settingsFolder + INI_FILE;  // "\Color_Cop.dat"
+    std::filesystem::path settingsFolder = GetSettingsFolder();
+    std::filesystem::path iniPath = settingsFolder / "Color_Cop.dat";
+    CString strInitFile(iniPath.wstring().c_str());
 
     TRACE(_T("Portable mode: %d\n"), m_PortableMode);
     TRACE(_T("INI path: %s\n"), strInitFile.GetString());
@@ -195,7 +198,7 @@ BOOL CColorCopApp::InitApplication() {
     } else {
         // First time running ColorCop
         if (!m_PortableMode) {
-            CreateDirectory(settingsFolder, NULL);
+            CreateDirectory(settingsFolder.wstring().c_str(), NULL);
         }
         LoadDefaultSettings();
         ClipOrCenterWindowToMonitor(::GetForegroundWindow(), MONITOR_CENTER);
@@ -233,8 +236,9 @@ void CColorCopApp::LoadDefaultSettings() {
 }
 
 void CColorCopApp::CloseApplication() {
-    CString settingsFolder = GetSettingsFolder();
-    CString strInitFile = settingsFolder + INI_FILE;
+    std::filesystem::path settingsFolder = GetSettingsFolder();
+    std::filesystem::path iniPath = settingsFolder / "Color_Cop.dat";
+    CString strInitFile(iniPath.wstring().c_str());
 
     TRACE(_T("Portable mode: %d\n"), m_PortableMode);
     TRACE(_T("INI path: %s\n"), strInitFile.GetString());
@@ -242,7 +246,7 @@ void CColorCopApp::CloseApplication() {
 
     if (!m_PortableMode) {
         // Ensure folder exists in installed mode
-        CreateDirectory(settingsFolder, NULL);
+        CreateDirectory(settingsFolder.wstring().c_str(), NULL);
     }
 
     CFile file;

--- a/ColorCop/ColorCop.h
+++ b/ColorCop/ColorCop.h
@@ -7,34 +7,34 @@
 #pragma once
 
 #ifndef __AFXWIN_H__
-    #error include 'pch.h' before including this file for PCH
+#error include 'pch.h' before including this file for PCH
 #endif
 
+#include <filesystem>
 
-#include "resource.h"        // main symbols
-#include "ColorCopDlg.h"    // Added by ClassView
+#include "resource.h"     // main symbols
+#include "ColorCopDlg.h"  // Added by ClassView
 
 /////////////////////////////////////////////////////////////////////////////
 // CColorCopApp:
 // See ColorCop.cpp for the implementation of this class
 //
 class CColorCopApp : public CWinApp {
- public:
+     public:
     bool m_PortableMode = false;  // set via command-line switches
 
     CColorCopDlg dlg;
     CColorCopApp();
     ~CColorCopApp();
-    /* Returns the folder used to store the application's persistent state,
-     * including ColorCop.ini and other configuration files. This ensures the
-     * user's settings and preferences are preserved across application
-     * launches. If the application is running in portable mode, this will
-     * return the executable directory. Otherwise, it will return a folder in
-     * the user's AppData directory.
+    /* Returns the filesystem path used to store the application's persistent
+     * state, including ColorCop.dat and other configuration files. In portable
+     * mode, this is the directory containing the executable. In installed mode,
+     * it is the user's LocalAppData\ColorCop folder. The returned value is a
+     * std::filesystem::path, allowing safe and Unicode‑aware path handling.
      */
-    CString GetSettingsFolder();
+    std::filesystem::path GetSettingsFolder();
 
- protected:
+     protected:
     void CloseApplication();
     void LoadDefaultSettings();
     BOOL GetShellFolderPath(LPCTSTR pShellFolder, LPTSTR pShellPath);
@@ -43,21 +43,21 @@ class CColorCopApp : public CWinApp {
     bool InstanceRunning();
     HANDLE m_hMutex;
 
-// Overrides
+    // Overrides
     // ClassWizard generated virtual function overrides
     //{{AFX_VIRTUAL(CColorCopApp) // NOLINT(whitespace/comments)
- public:
+     public:
     virtual BOOL InitInstance();
     bool BringExistingInstanceToFront();
     virtual BOOL InitApplication();
     virtual void Serialize(CArchive& ar);
     //}}AFX_VIRTUAL // NOLINT(whitespace/comments)
 
-// Implementation
+    // Implementation
 
     //{{AFX_MSG(CColorCopApp) // NOLINT(whitespace/comments)
-        // NOTE - the ClassWizard will add and remove member functions here.
-        //    DO NOT EDIT what you see in these blocks of generated code !
+    // NOTE - the ClassWizard will add and remove member functions here.
+    //    DO NOT EDIT what you see in these blocks of generated code !
     //}}AFX_MSG // NOLINT(whitespace/comments)
     DECLARE_MESSAGE_MAP()
 };

--- a/ColorCop/ColorCopDlg.cpp
+++ b/ColorCop/ColorCopDlg.cpp
@@ -489,8 +489,9 @@ bool CColorCopDlg::LoadPersistentVariables() {
 
     // Build full bitmap path safely
     auto* pApp = static_cast<CColorCopApp*>(AfxGetApp());
-    CString strBMPFile = pApp->GetSettingsFolder();
-    strBMPFile += BMP_FILE;
+
+    std::filesystem::path bmpPath = pApp->GetSettingsFolder() / BMP_FILE;
+    CString strBMPFile(bmpPath.wstring().c_str());
 
     TRACE(_T("BMP path: %s\n"), strBMPFile.GetString());
 
@@ -2271,8 +2272,9 @@ void CColorCopDlg::OnDestroy() {
 
     // save the bitmap
     auto* pApp = static_cast<CColorCopApp*>(AfxGetApp());
-    CString strBMPFile = pApp->GetSettingsFolder();
-    strBMPFile += BMP_FILE;
+
+    std::filesystem::path bmpPath = pApp->GetSettingsFolder() / BMP_FILE;
+    CString strBMPFile(bmpPath.wstring().c_str());
 
     TRACE(_T("Portable mode: %d\n"), m_PortableMode);
     TRACE(_T("BMP path: %s\n"), strBMPFile.GetString());


### PR DESCRIPTION
- Replace CString-based path construction with std::filesystem::path
- Update InitApplication, CloseApplication, LoadPersistentVariables, OnDestroy
- Convert paths to CString via .wstring() for MFC APIs
- Modernize GetSettingsFolder() with SHGetKnownFolderPath
- Fix CPPLINT.cfg filters for C++17 usage