### PR TITLE
fix(init): move m_MagLevel and m_FloatPrecision defaults to construct…

### DIFF
--- a/ColorCop/ColorCopDlg.cpp
+++ b/ColorCop/ColorCopDlg.cpp
@@ -122,7 +122,9 @@ CColorCopDlg::CColorCopDlg(CWnd* pParent /*=NULL*/)
       m_hHandCursor(nullptr),
       hIcon_(nullptr),
       pTrayIcon_(nullptr),
-      nTrayNotificationMsg_(0) {
+      nTrayNotificationMsg_(0),
+      m_MagLevel(kDefaultMagLevel),
+      m_FloatPrecision(kDefaultFloatPrecision) {
 
     m_brDarkMode.CreateSolidBrush(RGB(32, 32, 32));
     m_clrText = RGB(220, 220, 220);

--- a/ColorCop/ColorCopDlg.h
+++ b/ColorCop/ColorCopDlg.h
@@ -74,8 +74,8 @@ class CColorCopDlg : public CDialog {
 
     int WinLocX;
     int WinLocY;
-    int m_MagLevel = kDefaultMagLevel;
-    int m_FloatPrecision = kDefaultFloatPrecision;
+    int m_MagLevel;
+    int m_FloatPrecision;
 
     HBITMAP hBitmap, hBitmapClip, hZoomBitmap;
 


### PR DESCRIPTION
…or initializer list

Ensure both members are initialized before settings load and clamping, removing redundant in-class initializers and preventing undefined behavior.